### PR TITLE
Add CMake support to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
-# Directories
+# Editors
 .vs/
+.vscode/
+.atom/
+.idea/
+
+# Build & Binary
+Build/
+build/ 
 bin/
 bin-int/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.8)
+
+# Project
+project(Hazel)
+
+# Options
+option(HAZEL_BUILD_SANDBOX "Build sandbox application" ON)
+
+# Hazel
+add_subdirectory(Hazel)
+
+# Sandbox
+if(HAZEL_BUILD_SANDBOX)
+    add_subdirectory(Sandbox)
+endif()

--- a/Hazel/CMakeLists.txt
+++ b/Hazel/CMakeLists.txt
@@ -1,0 +1,40 @@
+project(hazel-engine)
+
+# Add sources (only .cpp)
+set (SANDBOX_SOURCES
+    src/Hazel/Application.cpp
+)
+
+# Define shared library
+# Create nice looking alias for clients of Hazel to link to 
+add_library(${PROJECT_NAME} SHARED ${SANDBOX_SOURCES})
+add_library(Hazel::Engine ALIAS ${PROJECT_NAME}) 
+
+# Platform specific preprocessor defines
+# PUBLIC  = define is visible to the user of Hazel
+# PRIVATE = define is visible Hazel only
+if (WIN32)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC HZ_PLATFORM_WINDOWS=1)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HZ_BUILD_DLL=1)
+endif()
+if(APPLE)
+    # for MacOS X or iOS, watchOS, tvOS (since 3.10.3)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC HZ_PLATFORM_APPLE=1)
+endif()
+if(UNIX AND NOT APPLE)
+    # for Linux, BSD, Solaris, Minix
+    target_compile_definitions(${PROJECT_NAME} PUBLIC HZ_PLATFORM_UNIX=1)
+endif()
+
+# Set include directories
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/Hazel)
+
+# Language standard
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+
+# Link libraries (e.g. logging)
+target_link_libraries(${PROJECT_NAME} 
+    # ${CMAKE_THREAD_LIBS_INIT}     # Needed for unix builds to link to pthread
+    # LOGGING
+)

--- a/Sandbox/CMakeLists.txt
+++ b/Sandbox/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(hazel-sandbox)
+
+# Add source files (.cpp only)
+set (SANDBOX_SOURCES
+    src/SandboxApp.cpp
+)
+
+# Define executable
+add_executable(${PROJECT_NAME} ${SANDBOX_SOURCES})
+# Set include directories
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/src)
+# Compiler standard
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+# Link libraries
+target_link_libraries(${PROJECT_NAME} Hazel::Engine)


### PR DESCRIPTION
Hi TheCherno,

I updated your project to be built with CMake. I thought it would be a good idea to start using CMake early on, so it will be easier to migrate to different platforms.

I only added three ```CMakeLists.txt``` files & updated ```.gitignore ```. I did no changes to the source code, so it's still windows only. The CMake project already has the necessary structure for future platforms & external libraries (e.g. logging). I tried to document the CMake files as much as possible, so hopefully, there are no unclear lines.

You can obviously still build the project using the Visual Studio solution file ```.sln```. I'm happy to maintain the CMake build files if you don't want to, but they only need to change for new c++ files, defines or new libraries anyway.

Here is an example on how to build the project with CMake from git-bash, since I'm not very familiar with cmd:

```sh
cd Hazel
mkdir build && cd build
cmake ..
cmake --build .
```
Then you can copy the hazel-engine.dll to the sandox folder and run the .exe

Hope this helps. 

Greetings,
**tobante**