### PR TITLE
Postbuild command for Hazel project modified

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -68,7 +68,7 @@ project "Hazel"
 
 		postbuildcommands
 		{
-			("{COPY} %{cfg.buildtarget.relpath} ../bin/" .. outputdir .. "/Sandbox")
+			("{COPY} %{cfg.buildtarget.relpath} \"../bin/" .. outputdir .. "/Sandbox/\"")
 		}
 
 	filter "configurations:Debug"

--- a/premake5.lua
+++ b/premake5.lua
@@ -134,5 +134,5 @@ project "Sandbox"
 
 	filter "configurations:Dist"
 		defines "HZ_DIST"
-    runtime "Release"
+		runtime "Release"
 		optimize "On"


### PR DESCRIPTION
this will ensure that XCOPY command will know that argument number 2  is folder not a file 