### PR TITLE
Modify Premake configuration to suppress warnings

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -1,6 +1,9 @@
 workspace "Hazel"
 	architecture "x64"
 	startproject "Sandbox"
+	
+	filter "system:windows"
+		disablewarnings { "4996", "4251" }
 
 	configurations
 	{


### PR DESCRIPTION
Hi Cherno, this is just a small change to suppress the warnings you mentioned in your latest video ([C4996](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996) and [C4251](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251) specifically) when compiling for Windows.