### PR TITLE
Fix iterator invalidation in LayerStack.

### DIFF
--- a/Hazel/src/Hazel/LayerStack.cpp
+++ b/Hazel/src/Hazel/LayerStack.cpp
@@ -21,7 +21,11 @@ namespace Hazel {
 
 	void LayerStack::PushOverlay(Layer* overlay)
 	{
+		const size_t insertIndex = m_LayerInsert - begin();
+
 		m_Layers.emplace_back(overlay);
+		// emplace might have invalidated the iterator, reconstruct it
+		m_LayerInsert = begin() + insertIndex;
 	}
 
 	void LayerStack::PopLayer(Layer* layer)


### PR DESCRIPTION
A call to `LayerStack::PushOverlay` can cause `m_Layers` to be resized and invalidate `m_LayerInsert`, which will lead to UB in subsequent `PushLayer`'s. This PR simply reconstructs the iterator to prevent nastiness.

Edit: seems I'm late to this particular party, https://github.com/TheCherno/Hazel/issues/34 already noticed the same issue.