### PR TITLE
Fixed LayerStack iterator invalidation

### DIFF
--- a/Hazel/src/Hazel/LayerStack.cpp
+++ b/Hazel/src/Hazel/LayerStack.cpp
@@ -5,7 +5,6 @@ namespace Hazel {
 
 	LayerStack::LayerStack()
 	{
-		m_LayerInsert = m_Layers.begin();
 	}
 
 	LayerStack::~LayerStack()
@@ -16,7 +15,8 @@ namespace Hazel {
 
 	void LayerStack::PushLayer(Layer* layer)
 	{
-		m_LayerInsert = m_Layers.emplace(m_LayerInsert, layer);
+		m_Layers.emplace(m_Layers.begin() + m_LayerCount, layer);
+		m_LayerCount++;
 	}
 
 	void LayerStack::PushOverlay(Layer* overlay)
@@ -26,17 +26,17 @@ namespace Hazel {
 
 	void LayerStack::PopLayer(Layer* layer)
 	{
-		auto it = std::find(m_Layers.begin(), m_Layers.end(), layer);
+		auto it = std::find(m_Layers.begin(), m_Layers.begin() + m_LayerCount, layer);
 		if (it != m_Layers.end())
 		{
 			m_Layers.erase(it);
-			m_LayerInsert--;
+			m_LayerCount--;
 		}
 	}
 
 	void LayerStack::PopOverlay(Layer* overlay)
 	{
-		auto it = std::find(m_Layers.begin(), m_Layers.end(), overlay);
+		auto it = std::find(m_Layers.begin() + m_LayerCount, m_Layers.end(), overlay);
 		if (it != m_Layers.end())
 			m_Layers.erase(it);
 	}

--- a/Hazel/src/Hazel/LayerStack.h
+++ b/Hazel/src/Hazel/LayerStack.h
@@ -22,7 +22,7 @@ namespace Hazel {
 		std::vector<Layer*>::iterator end() { return m_Layers.end(); }
 	private:
 		std::vector<Layer*> m_Layers;
-		std::vector<Layer*>::iterator m_LayerInsert;
+		size_t m_LayerCount = 0;
 	};
 
 }


### PR DESCRIPTION
This is an alternative, working solution to #35 (further discussed in #34)

The iterator m_LayerInsert was invalidated by
`LayerStack::PushLayer()` and `LayerStack::PopLayer()`.
This caused crashes.

The iterator `m_LayerInsert` has been replaced with a counter `m_LayerCount` holding
the amount of layers.

In Addition, calls to `LayerStack::PopLayer` can no longer erase overlays, and vice versa.