### PR TITLE
Added support for mode-switched fullscreen and borderless fullscreen

### DIFF
--- a/Hazel/src/Hazel/Window.h
+++ b/Hazel/src/Hazel/Window.h
@@ -7,16 +7,26 @@
 
 namespace Hazel {
 
+	enum WindowMode
+	{
+		WINDOWED,
+		FULL_SCREEN,
+		BORDERLESS
+	};
+
 	struct WindowProps
 	{
 		std::string Title;
 		unsigned int Width;
 		unsigned int Height;
 
+		WindowMode Mode;
+
 		WindowProps(const std::string& title = "Hazel Engine",
 			        unsigned int width = 1280,
-			        unsigned int height = 720)
-			: Title(title), Width(width), Height(height)
+			        unsigned int height = 720,
+			        WindowMode mode = WindowMode::WINDOWED)
+			: Title(title), Width(width), Height(height), Mode(mode)
 		{
 		}
 	};
@@ -38,6 +48,7 @@ namespace Hazel {
 		virtual void SetEventCallback(const EventCallbackFn& callback) = 0;
 		virtual void SetVSync(bool enabled) = 0;
 		virtual bool IsVSync() const = 0;
+		virtual void SetWindowMode(const WindowMode& mode, unsigned int width = 0, unsigned int height = 0) = 0;
 
 		virtual void* GetNativeWindow() const = 0;
 

--- a/Hazel/src/Platform/Windows/WindowsWindow.h
+++ b/Hazel/src/Platform/Windows/WindowsWindow.h
@@ -21,6 +21,7 @@ namespace Hazel {
 		inline void SetEventCallback(const EventCallbackFn& callback) override { m_Data.EventCallback = callback; }
 		void SetVSync(bool enabled) override;
 		bool IsVSync() const override;
+		void SetWindowMode(const WindowMode& mode, unsigned int width, unsigned int height) override;
 
 		inline virtual void* GetNativeWindow() const { return m_Window; }
 	private:
@@ -28,17 +29,27 @@ namespace Hazel {
 		virtual void Shutdown();
 	private:
 		GLFWwindow* m_Window;
+		GLFWmonitor* m_PrimaryMonitor; // Stores a reference to the primary monitor
+		GLFWvidmode m_BaseVideoMode;   // Stores the underlying video mode being used by the OS
 
 		struct WindowData
 		{
 			std::string Title;
 			unsigned int Width, Height;
 			bool VSync;
+			WindowMode Mode;
 
 			EventCallbackFn EventCallback;
 		};
 
 		WindowData m_Data;
+
+		struct WindowedModeParams {
+			unsigned int Width, Height;
+			int XPos, YPos;
+		};
+		WindowedModeParams m_OldWindowedParams;
+
 	};
 
 }


### PR DESCRIPTION
Added support for mode-switched full screen and borderless fullscreen to the window classes. Saves previous location and size of windowed mode window after full screen or borderless mode. All arguments optional so this is a non-breaking change to clients using Hazel's exposed API.