### PR TITLE
fixed wrong spdlog api call

### DIFF
--- a/Hazel/src/Hazel/Log.h
+++ b/Hazel/src/Hazel/Log.h
@@ -25,11 +25,11 @@ namespace Hazel {
 #define HZ_CORE_INFO(...)     ::Hazel::Log::GetCoreLogger()->info(__VA_ARGS__)
 #define HZ_CORE_WARN(...)     ::Hazel::Log::GetCoreLogger()->warn(__VA_ARGS__)
 #define HZ_CORE_ERROR(...)    ::Hazel::Log::GetCoreLogger()->error(__VA_ARGS__)
-#define HZ_CORE_FATAL(...)    ::Hazel::Log::GetCoreLogger()->fatal(__VA_ARGS__)
+#define HZ_CORE_FATAL(...)    ::Hazel::Log::GetCoreLogger()->critical(__VA_ARGS__)
 
 // Client log macros
 #define HZ_TRACE(...)	      ::Hazel::Log::GetClientLogger()->trace(__VA_ARGS__)
 #define HZ_INFO(...)	      ::Hazel::Log::GetClientLogger()->info(__VA_ARGS__)
 #define HZ_WARN(...)	      ::Hazel::Log::GetClientLogger()->warn(__VA_ARGS__)
 #define HZ_ERROR(...)	      ::Hazel::Log::GetClientLogger()->error(__VA_ARGS__)
-#define HZ_FATAL(...)	      ::Hazel::Log::GetClientLogger()->fatal(__VA_ARGS__)
+#define HZ_FATAL(...)	      ::Hazel::Log::GetClientLogger()->critical(__VA_ARGS__)


### PR DESCRIPTION
The last log level in spdlog is level::critical and not level::fatal and the method is critical() not fatal().