### PR TITLE
Take shared_ptr by value in VertexArray.

### DIFF
--- a/Hazel/src/Hazel/Renderer/VertexArray.h
+++ b/Hazel/src/Hazel/Renderer/VertexArray.h
@@ -13,8 +13,8 @@ namespace Hazel {
 		virtual void Bind() const = 0;
 		virtual void Unbind() const = 0;
 
-		virtual void AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer) = 0;
-		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) = 0;
+		virtual void AddVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer) = 0;
+		virtual void SetIndexBuffer(std::shared_ptr<IndexBuffer> indexBuffer) = 0;
 
 		virtual const std::vector<std::shared_ptr<VertexBuffer>>& GetVertexBuffers() const = 0;
 		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const = 0;

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -46,7 +46,7 @@ namespace Hazel {
 		glBindVertexArray(0);
 	}
 
-	void OpenGLVertexArray::AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer)
+	void OpenGLVertexArray::AddVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer)
 	{
 		HZ_CORE_ASSERT(vertexBuffer->GetLayout().GetElements().size(), "Vertex Buffer has no layout!");
 
@@ -67,15 +67,15 @@ namespace Hazel {
 			index++;
 		}
 
-		m_VertexBuffers.push_back(vertexBuffer);
+		m_VertexBuffers.push_back(std::move(vertexBuffer));
 	}
 
-	void OpenGLVertexArray::SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)
+	void OpenGLVertexArray::SetIndexBuffer(std::shared_ptr<IndexBuffer> indexBuffer)
 	{
 		glBindVertexArray(m_RendererID);
 		indexBuffer->Bind();
 
-		m_IndexBuffer = indexBuffer;
+		m_IndexBuffer = std::move(indexBuffer);
 	}
 
 }

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
@@ -13,8 +13,8 @@ namespace Hazel {
 		virtual void Bind() const override;
 		virtual void Unbind() const override;
 
-		virtual void AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer) override;
-		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) override;
+		virtual void AddVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer) override;
+		virtual void SetIndexBuffer(std::shared_ptr<IndexBuffer> indexBuffer) override;
 
 		virtual const std::vector<std::shared_ptr<VertexBuffer>>& GetVertexBuffers() const { return m_VertexBuffers; }
 		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const { return m_IndexBuffer; }


### PR DESCRIPTION
Take shared_ptr by value in VertexArray. This will potentially reduce the number of times the shared_ptr's ref count needs to be (atomically) incremented/decremented, which is a (relatively) slow operation. Therefore potentially increasing performance.