### PR TITLE
 Rename m_SceneData to s_SceneData

### DIFF
--- a/Hazel/src/Hazel/Renderer/Renderer.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer.cpp
@@ -3,11 +3,11 @@
 
 namespace Hazel {
 
-	Renderer::SceneData* Renderer::m_SceneData = new Renderer::SceneData;
+	Renderer::SceneData* Renderer::s_SceneData = new Renderer::SceneData;
 
 	void Renderer::BeginScene(OrthographicCamera& camera)
 	{
-		m_SceneData->ViewProjectionMatrix = camera.GetViewProjectionMatrix();
+		s_SceneData->ViewProjectionMatrix = camera.GetViewProjectionMatrix();
 	}
 
 	void Renderer::EndScene()
@@ -17,7 +17,7 @@ namespace Hazel {
 	void Renderer::Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<VertexArray>& vertexArray)
 	{
 		shader->Bind();
-		shader->UploadUniformMat4("u_ViewProjection", m_SceneData->ViewProjectionMatrix);
+		shader->UploadUniformMat4("u_ViewProjection", s_SceneData->ViewProjectionMatrix);
 
 		vertexArray->Bind();
 		RenderCommand::DrawIndexed(vertexArray);

--- a/Hazel/src/Hazel/Renderer/Renderer.h
+++ b/Hazel/src/Hazel/Renderer/Renderer.h
@@ -22,7 +22,7 @@ namespace Hazel {
 			glm::mat4 ViewProjectionMatrix;
 		};
 
-		static SceneData* m_SceneData;
+		static SceneData* s_SceneData;
 	};
 
 


### PR DESCRIPTION
This to be inline with cherno's naming convention;
 - `s_` prefix for static fields;
 - `m_` prefix for member fields.