### PR TITLE
Invert Camera's rotate direction.

### DIFF
--- a/Hazel/src/Hazel/Renderer/OrthographicCamera.cpp
+++ b/Hazel/src/Hazel/Renderer/OrthographicCamera.cpp
@@ -14,7 +14,7 @@ namespace Hazel {
 	void OrthographicCamera::RecalculateViewMatrix()
 	{
 		glm::mat4 transform = glm::translate(glm::mat4(1.0f), m_Position) *
-			glm::rotate(glm::mat4(1.0f), glm::radians(m_Rotation), glm::vec3(0, 0, 1));
+			glm::rotate(glm::mat4(1.0f), glm::radians(360.0f - m_Rotation), glm::vec3(0, 0, 1));
 
 		m_ViewMatrix = glm::inverse(transform);
 		m_ViewProjectionMatrix = m_ProjectionMatrix * m_ViewMatrix;


### PR DESCRIPTION
We have invert the View Matrix but that inversion only affect the position (or move direction) of the object.
When rotate Camera in one direction, the rendered object should be rotate in opposite direction, or the camera rotation should be inverted as well.