### PR TITLE
Fix warning casting from 'const uint32_t' to 'const void*'

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -63,7 +63,7 @@ namespace Hazel {
 				ShaderDataTypeToOpenGLBaseType(element.Type),
 				element.Normalized ? GL_TRUE : GL_FALSE,
 				layout.GetStride(),
-				(const void*)element.Offset);
+				(const void*)(intptr_t)element.Offset);
 			index++;
 		}
 


### PR DESCRIPTION
Fixed that lonely warning as it was working on my nerves...
![image](https://user-images.githubusercontent.com/26593477/62428399-ce917400-b701-11e9-84b5-56fc8273e818.png)

Fixed by first casting the integer to a pointer before casting to the void pointer.

Kind regards
lovely_santa