### PR TITLE
Fixed a bug in LayerStack which would occur if passing an overlay or …

### DIFF
--- a/Hazel/src/Hazel/LayerStack.cpp
+++ b/Hazel/src/Hazel/LayerStack.cpp
@@ -29,7 +29,7 @@ namespace Hazel {
 	void LayerStack::PopLayer(Layer* layer)
 	{
 		auto it = std::find(m_Layers.begin(), m_Layers.begin() + m_LayerInsertIndex, layer);
-		if (it != m_Layers.end())
+		if (it != m_Layers.begin() + m_LayerInsertIndex)
 		{
 			layer->OnDetach();
 			m_Layers.erase(it);


### PR DESCRIPTION
This PR fixes an issue that would occur when passing either an overlay or a non-existent layer in to PopLayer in LayerStack.  For the Find, it stops at the correct spot, but then compares the iterator to end(), which is incorrect when searching for a layer.

This PR resolves #87 