### PR TITLE
Fix a warning introduced by PR

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -53,22 +53,20 @@ namespace Hazel {
 		glBindVertexArray(m_RendererID);
 		vertexBuffer->Bind();
 
-		uint32_t index = 0;
 		const auto& layout = vertexBuffer->GetLayout();
 		for (const auto& element : layout)
 		{
-			glEnableVertexAttribArray(index + m_VertexBufferIndexOffset);
-			glVertexAttribPointer(index + m_VertexBufferIndexOffset,
+			glEnableVertexAttribArray(m_VertexBufferIndex);
+			glVertexAttribPointer(m_VertexBufferIndex,
 				element.GetComponentCount(),
 				ShaderDataTypeToOpenGLBaseType(element.Type),
 				element.Normalized ? GL_TRUE : GL_FALSE,
 				layout.GetStride(),
 				(const void*)(intptr_t)element.Offset);
-			index++;
+			m_VertexBufferIndex++;
 		}
 
 		m_VertexBuffers.push_back(vertexBuffer);
-		m_VertexBufferIndexOffset += index;
 	}
 
 	void OpenGLVertexArray::SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -68,7 +68,7 @@ namespace Hazel {
 		}
 
 		m_VertexBuffers.push_back(vertexBuffer);
-		m_VertexBufferIndexOffset += (uint32_t)layout.GetElements().size();
+		m_VertexBufferIndexOffset += index;
 	}
 
 	void OpenGLVertexArray::SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -68,7 +68,7 @@ namespace Hazel {
 		}
 
 		m_VertexBuffers.push_back(vertexBuffer);
-		m_VertexBufferIndexOffset += layout.GetElements().size();
+		m_VertexBufferIndexOffset += (uint32_t)layout.GetElements().size();
 	}
 
 	void OpenGLVertexArray::SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
@@ -20,7 +20,7 @@ namespace Hazel {
 		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const { return m_IndexBuffer; }
 	private:
 		uint32_t m_RendererID;
-		uint32_t m_VertexBufferIndexOffset = 0;
+		uint32_t m_VertexBufferIndex = 0;
 		std::vector<std::shared_ptr<VertexBuffer>> m_VertexBuffers;
 		std::shared_ptr<IndexBuffer> m_IndexBuffer;
 	};


### PR DESCRIPTION
Fix warning: '+=': conversion from 'size_t' to 'uint32_t', possible loss of data

Fixed by casting to ``uint32_t``.
![image](https://user-images.githubusercontent.com/21996470/63643325-1faadd00-c69c-11e9-9718-8a825adb3007.png)
