### PR TITLE
Avoid using std::function for performance

### DIFF
--- a/Hazel/src/Hazel/Events/Event.h
+++ b/Hazel/src/Hazel/Events/Event.h
@@ -58,7 +58,8 @@ namespace Hazel {
 			: m_Event(event)
 		{
 		}
-
+		
+		// F will be deduced by the compiler
 		template<typename T, typename F>
 		bool Dispatch(const F& func)
 		{

--- a/Hazel/src/Hazel/Events/Event.h
+++ b/Hazel/src/Hazel/Events/Event.h
@@ -53,20 +53,18 @@ namespace Hazel {
 
 	class EventDispatcher
 	{
-		template<typename T>
-		using EventFn = std::function<bool(T&)>;
 	public:
 		EventDispatcher(Event& event)
 			: m_Event(event)
 		{
 		}
 
-		template<typename T>
-		bool Dispatch(EventFn<T> func)
+		template<typename T, typename F>
+		bool Dispatch(const F& func)
 		{
 			if (m_Event.GetEventType() == T::GetStaticType())
 			{
-				m_Event.Handled = func(*(T*)&m_Event);
+				m_Event.Handled = func(static_cast<T&>(m_Event));
 				return true;
 			}
 			return false;


### PR DESCRIPTION
Avoiding the usage of std::function in event dispatcher for performance. This has an 20%+ improvement in speed. You can read more about this via issue #85. 

Full credit to @Chlorie for this.

This PR was never made so I've decided to make it.
This resolves #85.