### PR TITLE
Change bind target inside OpenGLIndexBuffer constructor

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -39,8 +39,8 @@ namespace Hazel {
 		: m_Count(count)
 	{
 		glCreateBuffers(1, &m_RendererID);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
+		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+		glBufferData(GL_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
 	}
 
 	OpenGLIndexBuffer::~OpenGLIndexBuffer()


### PR DESCRIPTION
According to [OpenGL 4.6 Core Profile Specification](https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf) and [Khronos Wiki](https://www.khronos.org/opengl/wiki/Vertex_Specification#Vertex_Array_Object),

> [it is invalid to] modify or query buffer object state for a target bound to zero, since there is no buffer object corresponding to the name zero.
*(OpenGL Specification, page 62)*

> The core OpenGL profile makes VAO object 0 not an object at all. So if VAO 0 is bound in the core profile, you should not call any function that modifies VAO state.
*(Khronos Wiki, last paragraph of Vertex Array Object)*

Element array buffer binding is a part of VAO state *(OpenGL Specification, page 586)*.

This PR modifies the OpenGLIndexBuffer constructor, so that index buffer is initialized while bound to `GL_ARRAY_BUFFER`.

Closes #95