### PR TITLE
Made Input a Singleton

### DIFF
--- a/Hazel/src/Hazel/Input.h
+++ b/Hazel/src/Hazel/Input.h
@@ -6,7 +6,12 @@ namespace Hazel {
 
 	class HAZEL_API Input
 	{
+	protected:
+		Input() = default;
 	public:
+		Input(const Input&) = delete;
+		Input& operator=(const Input&) = delete;
+
 		inline static bool IsKeyPressed(int keycode) { return s_Instance->IsKeyPressedImpl(keycode); }
 
 		inline static bool IsMouseButtonPressed(int button) { return s_Instance->IsMouseButtonPressedImpl(button); }


### PR DESCRIPTION
Implemented the Singleton design pattern for the Input class by deleting copy constructor and copy-assignment operator and adding protected default constructor. Credit to @moskittle for pointing it out.

Resolves #97