### PR TITLE
Remove unnecessary token-pasting operator in EVENT_CLASS_TYPE

### DIFF
--- a/Hazel/src/Hazel/Events/Event.h
+++ b/Hazel/src/Hazel/Events/Event.h
@@ -29,7 +29,7 @@ namespace Hazel {
 		EventCategoryMouseButton    = BIT(4)
 	};
 
-#define EVENT_CLASS_TYPE(type) static EventType GetStaticType() { return EventType::##type; }\
+#define EVENT_CLASS_TYPE(type) static EventType GetStaticType() { return EventType::type; }\
 								virtual EventType GetEventType() const override { return GetStaticType(); }\
 								virtual const char* GetName() const override { return #type; }
 


### PR DESCRIPTION
avoids warnings from compiler