### PR TITLE
File path correction for developmental builds

### DIFF
--- a/Hazel/src/Hazel/Application.cpp
+++ b/Hazel/src/Hazel/Application.cpp
@@ -78,4 +78,23 @@ namespace Hazel {
 		return true;
 	}
 
+	std::string Application::CorrectFilePath(const std::string& path)
+	{
+		#if defined(HZ_DEBUG) || defined(HZ_RELEASE)
+			struct stat buffer;
+			int status;
+
+			std::vector<std::string>prepath_string_vector = {"", "./Sandbox/", "../../../Sandbox/"};
+			for (auto path_iter : prepath_string_vector)
+			{
+				std::string modified_path = path_iter + path;
+				status = stat(modified_path.c_str(), &buffer);
+
+				if (status == 0)
+					return modified_path;
+			}
+		#endif
+
+		return path;
+	}
 }

--- a/Hazel/src/Hazel/Application.h
+++ b/Hazel/src/Hazel/Application.h
@@ -29,6 +29,7 @@ namespace Hazel {
 		inline Window& GetWindow() { return *m_Window; }
 
 		inline static Application& Get() { return *s_Instance; }
+		static std::string CorrectFilePath(const std::string&);
 	private:
 		bool OnWindowClose(WindowCloseEvent& e);
 	private:

--- a/Hazel/src/Hazel/Renderer/Shader.cpp
+++ b/Hazel/src/Hazel/Renderer/Shader.cpp
@@ -3,6 +3,7 @@
 
 #include "Renderer.h"
 #include "Platform/OpenGL/OpenGLShader.h"
+#include "Hazel/Application.h"
 
 namespace Hazel {
 
@@ -11,7 +12,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(filepath);
+			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(Application::CorrectFilePath(filepath));
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Texture.cpp
+++ b/Hazel/src/Hazel/Renderer/Texture.cpp
@@ -3,6 +3,7 @@
 
 #include "Renderer.h"
 #include "Platform/OpenGL/OpenGLTexture.h"
+#include "Hazel/Application.h"
 
 namespace Hazel {
 
@@ -11,7 +12,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(path);
+			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(Application::CorrectFilePath(path));
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");


### PR DESCRIPTION
Added a function to correct the file path when running with the wrong current working directory, such as when Sandbox is run outside of an IDE.
@LovelySanta 