### PR TITLE
File path correction for developmental builds 2

### DIFF
--- a/Hazel/src/Hazel/Application.cpp
+++ b/Hazel/src/Hazel/Application.cpp
@@ -78,4 +78,23 @@ namespace Hazel {
 		return true;
 	}
 
+	std::string Application::CorrectFilePath(const std::string& path)
+	{
+		#if defined(HZ_DEBUG) || defined(HZ_RELEASE)
+			struct stat buffer;
+			int status;
+
+			std::vector<std::string>prepath_string_vector = {"", "./Sandbox/", "../../../Sandbox/"};
+			for (auto path_iter : prepath_string_vector)
+			{
+				std::string modified_path = path_iter + path;
+				status = stat(modified_path.c_str(), &buffer);
+
+				if (status == 0)
+					return modified_path;
+			}
+		#endif
+
+		return path;
+	}
 }

--- a/Hazel/src/Hazel/Application.cpp
+++ b/Hazel/src/Hazel/Application.cpp
@@ -7,7 +7,8 @@
 
 #include "Input.h"
 
-#include <glfw/glfw3.h>
+#include <GLFW/glfw3.h>
+#include <filesystem>
 
 namespace Hazel {
 
@@ -15,10 +16,12 @@ namespace Hazel {
 
 	Application* Application::s_Instance = nullptr;
 
-	Application::Application()
+	Application::Application(std::string base_directory)
 	{
 		HZ_CORE_ASSERT(!s_Instance, "Application already exists!");
 		s_Instance = this;
+
+		m_base_directory = base_directory;
 
 		m_Window = std::unique_ptr<Window>(Window::Create());
 		m_Window->SetEventCallback(BIND_EVENT_FN(OnEvent));
@@ -81,16 +84,11 @@ namespace Hazel {
 	std::string Application::CorrectFilePath(const std::string& path)
 	{
 		#if defined(HZ_DEBUG) || defined(HZ_RELEASE)
-			struct stat buffer;
-			int status;
-
-			std::vector<std::string>prepath_string_vector = {"", "./Sandbox/", "../../../Sandbox/"};
+			std::vector<std::string>prepath_string_vector = {"", "./" + m_base_directory + "/", "../../../" + m_base_directory + "/"};
 			for (auto path_iter : prepath_string_vector)
 			{
 				std::string modified_path = path_iter + path;
-				status = stat(modified_path.c_str(), &buffer);
-
-				if (status == 0)
+				if (std::filesystem::exists(modified_path) == true)
 					return modified_path;
 			}
 		#endif

--- a/Hazel/src/Hazel/Application.h
+++ b/Hazel/src/Hazel/Application.h
@@ -29,6 +29,7 @@ namespace Hazel {
 		inline Window& GetWindow() { return *m_Window; }
 
 		inline static Application& Get() { return *s_Instance; }
+		static std::string CorrectFilePath(const std::string&);
 	private:
 		bool OnWindowClose(WindowCloseEvent& e);
 	private:

--- a/Hazel/src/Hazel/Application.h
+++ b/Hazel/src/Hazel/Application.h
@@ -16,7 +16,7 @@ namespace Hazel {
 	class Application
 	{
 	public:
-		Application();
+		Application(std::string);
 		virtual ~Application() = default;
 
 		void Run();
@@ -29,7 +29,7 @@ namespace Hazel {
 		inline Window& GetWindow() { return *m_Window; }
 
 		inline static Application& Get() { return *s_Instance; }
-		static std::string CorrectFilePath(const std::string&);
+		std::string CorrectFilePath(const std::string&);
 	private:
 		bool OnWindowClose(WindowCloseEvent& e);
 	private:
@@ -40,6 +40,7 @@ namespace Hazel {
 		float m_LastFrameTime = 0.0f;
 	private:
 		static Application* s_Instance;
+		std::string m_base_directory;
 	};
 
 	// To be defined in CLIENT

--- a/Hazel/src/Hazel/Renderer/Shader.cpp
+++ b/Hazel/src/Hazel/Renderer/Shader.cpp
@@ -3,6 +3,7 @@
 
 #include "Renderer.h"
 #include "Platform/OpenGL/OpenGLShader.h"
+#include "Hazel/Application.h"
 
 namespace Hazel {
 
@@ -11,7 +12,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(filepath);
+			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(Application::CorrectFilePath(filepath));
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Shader.cpp
+++ b/Hazel/src/Hazel/Renderer/Shader.cpp
@@ -12,7 +12,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(Application::CorrectFilePath(filepath));
+			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(Application::Get().CorrectFilePath(filepath));
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Texture.cpp
+++ b/Hazel/src/Hazel/Renderer/Texture.cpp
@@ -3,6 +3,7 @@
 
 #include "Renderer.h"
 #include "Platform/OpenGL/OpenGLTexture.h"
+#include "Hazel/Application.h"
 
 namespace Hazel {
 
@@ -11,7 +12,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(path);
+			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(Application::CorrectFilePath(path));
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Texture.cpp
+++ b/Hazel/src/Hazel/Renderer/Texture.cpp
@@ -12,7 +12,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(Application::CorrectFilePath(path));
+			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(Application::Get().CorrectFilePath(path));
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -223,7 +223,7 @@ private:
 class Sandbox : public Hazel::Application
 {
 public:
-	Sandbox()
+	Sandbox(std::string base_directory) : Hazel::Application(base_directory)
 	{
 		PushLayer(new ExampleLayer());
 	}
@@ -237,5 +237,5 @@ public:
 
 Hazel::Application* Hazel::CreateApplication()
 {
-	return new Sandbox();
+	return new Sandbox("Sandbox");
 }


### PR DESCRIPTION
Added a function to correct the file path when running with the wrong current working directory, such as when Sandbox is run outside of an IDE.

New in this second attempt PR is a switch to `std::filesystem` of C++17 away from POSIX C and removal of the hard coding of _Sandbox_ in the Hazel code base.

Linux Note: This patch needs `libstdc++fs` (_"stdc++fs"_) added to the premake config for GCC versions 5.3 to 8.x support of `std::filesystem`.