### PR TITLE
A Couple of memory leaks caused by left-over GL-Objects

### DIFF
--- a/Hazel/src/Hazel/Input.h
+++ b/Hazel/src/Hazel/Input.h
@@ -26,7 +26,7 @@ namespace Hazel {
 		virtual float GetMouseXImpl() = 0;
 		virtual float GetMouseYImpl() = 0;
 	private:
-		static Input* s_Instance;
+		static Hazel::Scope<Input> s_Instance;
 	};
 
 }

--- a/Hazel/src/Hazel/LayerStack.cpp
+++ b/Hazel/src/Hazel/LayerStack.cpp
@@ -10,7 +10,10 @@ namespace Hazel {
 	LayerStack::~LayerStack()
 	{
 		for (Layer* layer : m_Layers)
+		{
+			layer->OnDetach();
 			delete layer;
+		}
 	}
 
 	void LayerStack::PushLayer(Layer* layer)

--- a/Hazel/src/Hazel/Renderer/RenderCommand.cpp
+++ b/Hazel/src/Hazel/Renderer/RenderCommand.cpp
@@ -5,6 +5,6 @@
 
 namespace Hazel {
 
-	RendererAPI* RenderCommand::s_RendererAPI = new OpenGLRendererAPI;
+	Hazel::Scope<RendererAPI> RenderCommand::s_RendererAPI(new OpenGLRendererAPI);
 
 }

--- a/Hazel/src/Hazel/Renderer/RenderCommand.h
+++ b/Hazel/src/Hazel/Renderer/RenderCommand.h
@@ -27,7 +27,7 @@ namespace Hazel {
 			s_RendererAPI->DrawIndexed(vertexArray);
 		}
 	private:
-		static RendererAPI* s_RendererAPI;
+		static Hazel::Scope<RendererAPI> s_RendererAPI;
 	};
 
 }

--- a/Hazel/src/Hazel/Renderer/Renderer.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer.cpp
@@ -5,7 +5,7 @@
 
 namespace Hazel {
 
-	Renderer::SceneData* Renderer::s_SceneData = new Renderer::SceneData;
+	Hazel::Scope<Renderer::SceneData> Renderer::s_SceneData(new Renderer::SceneData);
 
 	void Renderer::Init()
 	{

--- a/Hazel/src/Hazel/Renderer/Renderer.h
+++ b/Hazel/src/Hazel/Renderer/Renderer.h
@@ -24,7 +24,7 @@ namespace Hazel {
 			glm::mat4 ViewProjectionMatrix;
 		};
 
-		static SceneData* s_SceneData;
+		static Hazel::Scope<SceneData> s_SceneData;
 	};
 
 

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -158,7 +158,10 @@ namespace Hazel {
 		}
 
 		for (auto id : glShaderIDs)
+		{
 			glDetachShader(program, id);
+			glDeleteShader(id);
+		}
 	}
 
 	void OpenGLShader::Bind() const

--- a/Hazel/src/Platform/Windows/WindowsInput.cpp
+++ b/Hazel/src/Platform/Windows/WindowsInput.cpp
@@ -6,7 +6,7 @@
 
 namespace Hazel {
 
-	Input* Input::s_Instance = new WindowsInput();
+	Hazel::Scope<Input> Input::s_Instance(new WindowsInput());
 
 	bool WindowsInput::IsKeyPressedImpl(int keycode)
 	{

--- a/Hazel/src/Platform/Windows/WindowsWindow.h
+++ b/Hazel/src/Platform/Windows/WindowsWindow.h
@@ -29,7 +29,7 @@ namespace Hazel {
 		virtual void Shutdown();
 	private:
 		GLFWwindow* m_Window;
-		GraphicsContext* m_Context;
+		Hazel::Scope<GraphicsContext> m_Context;
 
 		struct WindowData
 		{


### PR DESCRIPTION
Since i've seen a couple of issues about memory leaks (i was never able to reproduce myself) i wanted to give it a chance to test if there is actually any leaks in the Engine, so i attached the Sandbox.exe to CodeXL and ran it, didn't notice anything unusual; But, after terminating the application, i got this:

![Screenshot_1](https://user-images.githubusercontent.com/32076082/64921977-bb2dfa00-d7d1-11e9-809d-b6b0fa17c381.png)

so i started looking around to check if there is any GL-Objects left over, and there was!
in OpenGLShader.cpp (line 160) in the for-loop we are detaching the shaders from the program but never actually deleting them! and since there isn't any stored reference to them, they're leaked after the function returns, so to fix it i added a `glDeleteShader(id)` in the loop, and re-ran the test, and:

![Screenshot_3](https://user-images.githubusercontent.com/32076082/64922026-94bc8e80-d7d2-11e9-8a68-d0b67b798810.png)

as we can see there is still 6 objects being leaked, i have no idea where from but i'm still investigating the issue; Any ideas?