### PR TITLE
Delete the shaders after the shader program Creation

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -158,7 +158,10 @@ namespace Hazel {
 		}
 
 		for (auto id : glShaderIDs)
+		{
 			glDetachShader(program, id);
+			glDeleteShader(id);
+		}
 	}
 
 	void OpenGLShader::Bind() const


### PR DESCRIPTION
After successfully creating the shader program, the shaders should be deleted since they're probably not needed anymore.
the leaks where discovered in #125 