### PR TITLE
Fixed OpenGLShader::PreProcess Logic (issue #120)

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -73,18 +73,18 @@ namespace Hazel {
 
 		const char* typeToken = "#type";
 		size_t typeTokenLength = strlen(typeToken);
-		size_t pos = source.find(typeToken, 0);												//Start of shader type declaration line
+		size_t pos = source.find(typeToken, 0);                                             //Start of shader type declaration line
 		while (pos != std::string::npos)
 		{
-			size_t eol = source.find_first_of("\r\n", pos);									//End of shader type declaration line
+			size_t eol = source.find_first_of("\r\n", pos);                                 //End of shader type declaration line
 			HZ_CORE_ASSERT(eol != std::string::npos, "Syntax error");
-			size_t begin = pos + typeTokenLength + 1;										//Start of shader type name (after "#type " keyword)
+			size_t begin = pos + typeTokenLength + 1;                                       //Start of shader type name (after "#type " keyword)
 			std::string type = source.substr(begin, eol - begin);
 			HZ_CORE_ASSERT(ShaderTypeFromString(type), "Invalid shader type specified");
 
-			size_t nextLinePos = source.find_first_not_of("\r\n", eol);						//Start of shader code after shader type declaration line
+			size_t nextLinePos = source.find_first_not_of("\r\n", eol);                     //Start of shader code after shader type declaration line
 			HZ_CORE_ASSERT(nextLinePos != std::string::npos, "Syntax error");
-			pos = source.find(typeToken, nextLinePos);										//Start of next shader type declaration line
+			pos = source.find(typeToken, nextLinePos);                                      //Start of next shader type declaration line
 
 			if (pos == std::string::npos) shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos);
 			else shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos, pos - nextLinePos);

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -86,8 +86,7 @@ namespace Hazel {
 			HZ_CORE_ASSERT(nextLinePos != std::string::npos, "Syntax error");
 			pos = source.find(typeToken, nextLinePos); //Start of next shader type declaration line
 
-			if (pos == std::string::npos) shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos);
-			else shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos, pos - nextLinePos);
+			shaderSources[ShaderTypeFromString(type)] = (pos == std::string::npos) ? source.substr(nextLinePos) : source.substr(nextLinePos, pos - nextLinePos);
 		}
 
 		return shaderSources;

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -73,18 +73,21 @@ namespace Hazel {
 
 		const char* typeToken = "#type";
 		size_t typeTokenLength = strlen(typeToken);
-		size_t pos = source.find(typeToken, 0);
+		size_t pos = source.find(typeToken, 0);												//Start of shader type declaration line
 		while (pos != std::string::npos)
 		{
-			size_t eol = source.find_first_of("\r\n", pos);
+			size_t eol = source.find_first_of("\r\n", pos);									//End of shader type declaration line
 			HZ_CORE_ASSERT(eol != std::string::npos, "Syntax error");
-			size_t begin = pos + typeTokenLength + 1;
+			size_t begin = pos + typeTokenLength + 1;										//Start of shader type name (after "#type " keyword)
 			std::string type = source.substr(begin, eol - begin);
 			HZ_CORE_ASSERT(ShaderTypeFromString(type), "Invalid shader type specified");
 
-			size_t nextLinePos = source.find_first_not_of("\r\n", eol);
-			pos = source.find(typeToken, nextLinePos);
-			shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos, pos - (nextLinePos == std::string::npos ? source.size() - 1 : nextLinePos));
+			size_t nextLinePos = source.find_first_not_of("\r\n", eol);						//Start of shader code after shader type declaration line
+			HZ_CORE_ASSERT(nextLinePos != std::string::npos, "Syntax error");
+			pos = source.find(typeToken, nextLinePos);										//Start of next shader type declaration line
+
+			if (pos == std::string::npos) shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos);
+			else shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos, pos - nextLinePos);
 		}
 
 		return shaderSources;

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -73,18 +73,18 @@ namespace Hazel {
 
 		const char* typeToken = "#type";
 		size_t typeTokenLength = strlen(typeToken);
-		size_t pos = source.find(typeToken, 0);                                             //Start of shader type declaration line
+		size_t pos = source.find(typeToken, 0); //Start of shader type declaration line
 		while (pos != std::string::npos)
 		{
-			size_t eol = source.find_first_of("\r\n", pos);                                 //End of shader type declaration line
+			size_t eol = source.find_first_of("\r\n", pos); //End of shader type declaration line
 			HZ_CORE_ASSERT(eol != std::string::npos, "Syntax error");
-			size_t begin = pos + typeTokenLength + 1;                                       //Start of shader type name (after "#type " keyword)
+			size_t begin = pos + typeTokenLength + 1; //Start of shader type name (after "#type " keyword)
 			std::string type = source.substr(begin, eol - begin);
 			HZ_CORE_ASSERT(ShaderTypeFromString(type), "Invalid shader type specified");
 
-			size_t nextLinePos = source.find_first_not_of("\r\n", eol);                     //Start of shader code after shader type declaration line
+			size_t nextLinePos = source.find_first_not_of("\r\n", eol); //Start of shader code after shader type declaration line
 			HZ_CORE_ASSERT(nextLinePos != std::string::npos, "Syntax error");
-			pos = source.find(typeToken, nextLinePos);                                      //Start of next shader type declaration line
+			pos = source.find(typeToken, nextLinePos); //Start of next shader type declaration line
 
 			if (pos == std::string::npos) shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos);
 			else shaderSources[ShaderTypeFromString(type)] = source.substr(nextLinePos, pos - nextLinePos);


### PR DESCRIPTION
---
name: 'Pull Request: Implemented issue'
about: Fixes and explanatory comments for OpenGLShader::PreProcess
title: Fixed OpenGLShader::PreProcess logic (issue #120)
labels: ''
assignees: ''

---

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

Impact                   | Issue/PR
------------------------ | ------
Relevant issue           | Resolves #120
Other issues this solves | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
We add two steps:
1. Assert that `nextLinePos` is not `std::string::npos`.
2. Split the final assign operation to let the substring run to the end of the file if `pos` is `std::string::npos` (if there is no next `#type` token).

We also add comments to clarify the purpose of each variable.

#### Additional context
This compiles and runs without error on the latest commit of Hazel.