### PR TITLE
Implemented the Repeat Count for KeyPressed Events

### DIFF
--- a/Hazel/src/Hazel/Events/KeyEvent.h
+++ b/Hazel/src/Hazel/Events/KeyEvent.h
@@ -23,7 +23,7 @@ namespace Hazel {
 		KeyPressedEvent(int keycode, int repeatCount)
 			: KeyEvent(keycode), m_RepeatCount(repeatCount) {}
 
-		inline int GetRepeatCount() const { return m_RepeatCount; }
+		inline int GetRepeatCount() const { return m_RepeatCount; } //The Repeat Count is number of times the key event has repeated. So on the third time the event triggers it has repeated twice.
 
 		std::string ToString() const override
 		{

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -90,7 +90,7 @@ namespace Hazel {
 				}
 				case GLFW_RELEASE:
 				{
-					s_KeyRepeatCounts[key] = 0;
+					s_KeyRepeatCounts.erase(key);
 					KeyReleasedEvent event(key);
 					data.EventCallback(event);
 					break;

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -10,6 +10,7 @@
 namespace Hazel {
 	
 	static bool s_GLFWInitialized = false;
+	static std::unordered_map<int16_t, unsigned int> s_KeyRepeatCounts;
 
 	static void GLFWErrorCallback(int error, const char* description)
 	{
@@ -77,24 +78,27 @@ namespace Hazel {
 		glfwSetKeyCallback(m_Window, [](GLFWwindow* window, int key, int scancode, int action, int mods)
 		{
 			WindowData& data = *(WindowData*)glfwGetWindowUserPointer(window);
-
+			
 			switch (action)
 			{
 				case GLFW_PRESS:
 				{
+					s_KeyRepeatCounts[key] = 0;
 					KeyPressedEvent event(key, 0);
 					data.EventCallback(event);
 					break;
 				}
 				case GLFW_RELEASE:
 				{
+					s_KeyRepeatCounts[key] = 0;
 					KeyReleasedEvent event(key);
 					data.EventCallback(event);
 					break;
 				}
 				case GLFW_REPEAT:
 				{
-					KeyPressedEvent event(key, 1);
+					s_KeyRepeatCounts[key]++;
+					KeyPressedEvent event(key, s_KeyRepeatCounts[key]);
 					data.EventCallback(event);
 					break;
 				}
@@ -149,6 +153,8 @@ namespace Hazel {
 
 	void WindowsWindow::Shutdown()
 	{
+		s_KeyRepeatCounts.clear();
+		
 		glfwDestroyWindow(m_Window);
 	}
 


### PR DESCRIPTION
#### Describe the issue
Currently we are simply making the repeat count 0 if it's the first press and 1 otherwise.

#### Expected behavior
You would expect the repeat count to increment for each time the same key's `KeyPressedEvent` is created.

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
We want to store the repeat counts of the keys somehow. We need the method of storage to satisfy the following:

1. Can store key counts for multiple keys.
2. Is relatively fast seeing as it needs to be accessed every time a `KeyPressedEvent` is created.
3. Doesn't use memory for a key that is held once and then left alone for the rest of the application's runtime. Basically it should be able to erase the key's entry relatively fast when the key is released (optional).

I have implemented this with a static `unordered_map` in `WindowsWindow.cpp` to track the repeat count of each key. I am open to other suggestions.

I also added a comment (in `KeyEvent.h`) to clarify that the repeat count is how many times the event has been repeated, not how many times it has fired in total. So on the third event it has repeated twice, not three times.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Other issues this solves | None
Other PRs this solves    | None

#### Additional context
This compiles and works on the latest Hazel commit (734ea18).

I also want to note some (maybe) odd behaviour when holding a key (say W) and pressing and releasing another key (say S) while still holding the first key all the while. After doing this no more `KeyPressedEvent`s will be released even though W is still being held. This seems to be due to how GLFW works and I guess how they define a `GLFW_REPEAT` (Key Repeat) event. I am not sure if we want to do something about this.