### PR TITLE
Fix the C26495 warning.

### DIFF
--- a/Hazel/src/Hazel/Renderer/Buffer.h
+++ b/Hazel/src/Hazel/Renderer/Buffer.h
@@ -36,7 +36,10 @@ namespace Hazel {
 		uint32_t Offset;
 		bool Normalized;
 
-		BufferElement() {}
+		BufferElement()
+            		: Name(""), Type(), Size(0), Offset(0), Normalized(false)
+		{
+		}
 
 		BufferElement(ShaderDataType type, const std::string& name, bool normalized = false)
 			: Name(name), Type(type), Size(ShaderDataTypeSize(type)), Offset(0), Normalized(normalized)


### PR DESCRIPTION
Fixed the warning as per Cherno's request. There are more similar warnings in the project but they're related to spdlog, specifically the 'fmt' library.