### PR TITLE
Fix Build warnings to do with BufferElement Offset Type

### DIFF
--- a/Hazel/src/Hazel/Renderer/Buffer.h
+++ b/Hazel/src/Hazel/Renderer/Buffer.h
@@ -33,10 +33,10 @@ namespace Hazel {
 		std::string Name;
 		ShaderDataType Type;
 		uint32_t Size;
-		uint32_t Offset;
+		intptr_t Offset;
 		bool Normalized;
 
-		BufferElement() {}
+		BufferElement() = default;
 
 		BufferElement(ShaderDataType type, const std::string& name, bool normalized = false)
 			: Name(name), Type(type), Size(ShaderDataTypeSize(type)), Offset(0), Normalized(normalized)

--- a/Hazel/src/Hazel/Renderer/Buffer.h
+++ b/Hazel/src/Hazel/Renderer/Buffer.h
@@ -33,7 +33,7 @@ namespace Hazel {
 		std::string Name;
 		ShaderDataType Type;
 		uint32_t Size;
-		intptr_t Offset;
+		size_t Offset;
 		bool Normalized;
 
 		BufferElement() = default;
@@ -86,7 +86,7 @@ namespace Hazel {
 	private:
 		void CalculateOffsetsAndStride()
 		{
-			uint32_t offset = 0;
+			size_t offset = 0;
 			m_Stride = 0;
 			for (auto& element : m_Elements)
 			{

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -62,7 +62,7 @@ namespace Hazel {
 				ShaderDataTypeToOpenGLBaseType(element.Type),
 				element.Normalized ? GL_TRUE : GL_FALSE,
 				layout.GetStride(),
-				(const void*)(intptr_t)element.Offset);
+				(const void*)element.Offset);
 			m_VertexBufferIndex++;
 		}
 


### PR DESCRIPTION
This has been previously fixed, however the fix was to add a cast between the value and the (const void*) cast. This is a bad solution as it does not actually solve the problem behind the warning. just suppresses it.
The correct solution is to make the Offset member the correct type so that it is guaranteed to be the correct size to hold a pointer.
Also the Default constructor was not initializing any of the members so I made = default to get expected behavior.