### PR TITLE
Cm create functions

### DIFF
--- a/Hazel/src/Hazel/Renderer/Buffer.cpp
+++ b/Hazel/src/Hazel/Renderer/Buffer.cpp
@@ -19,12 +19,12 @@ namespace Hazel {
 		return nullptr;
 	}
 
-	IndexBuffer* IndexBuffer::Create(uint32_t* indices, uint32_t size)
+	Ref<IndexBuffer> IndexBuffer::Create(uint32_t* indices, uint32_t size)
 	{
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return new OpenGLIndexBuffer(indices, size);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLIndexBuffer>(indices, size);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Buffer.cpp
+++ b/Hazel/src/Hazel/Renderer/Buffer.cpp
@@ -7,12 +7,12 @@
 
 namespace Hazel {
 
-	VertexBuffer* VertexBuffer::Create(float* vertices, uint32_t size)
+	Ref<VertexBuffer> VertexBuffer::Create(float* vertices, uint32_t size)
 	{
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return new OpenGLVertexBuffer(vertices, size);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLVertexBuffer>(vertices, size);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Buffer.h
+++ b/Hazel/src/Hazel/Renderer/Buffer.h
@@ -111,7 +111,7 @@ namespace Hazel {
 		virtual const BufferLayout& GetLayout() const = 0;
 		virtual void SetLayout(const BufferLayout& layout) = 0;
 
-		static VertexBuffer* Create(float* vertices, uint32_t size);
+		static Ref<VertexBuffer> Create(float* vertices, uint32_t size);
 	};
 
 	class IndexBuffer

--- a/Hazel/src/Hazel/Renderer/Buffer.h
+++ b/Hazel/src/Hazel/Renderer/Buffer.h
@@ -124,7 +124,7 @@ namespace Hazel {
 
 		virtual uint32_t GetCount() const = 0;
 
-		static IndexBuffer* Create(uint32_t* indices, uint32_t size);
+		static Ref<IndexBuffer> Create(uint32_t* indices, uint32_t size);
 	};
 
 }

--- a/Hazel/src/Hazel/Renderer/GraphicsContext.cpp
+++ b/Hazel/src/Hazel/Renderer/GraphicsContext.cpp
@@ -1,0 +1,21 @@
+#include "hzpch.h"
+#include "GraphicsContext.h"
+
+#include "Renderer.h"
+#include "Platform/OpenGL/OpenGLContext.h"
+
+namespace Hazel {
+
+	Scope<GraphicsContext> GraphicsContext::Create(void* window)
+	{
+		switch (Renderer::GetAPI())
+		{
+			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
+			case RendererAPI::API::OpenGL:  return CreateScope<OpenGLContext>(static_cast<GLFWwindow*>(window));
+		}
+
+		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");
+		return nullptr;
+	}
+
+}

--- a/Hazel/src/Hazel/Renderer/GraphicsContext.h
+++ b/Hazel/src/Hazel/Renderer/GraphicsContext.h
@@ -7,6 +7,8 @@ namespace Hazel {
 	public:
 		virtual void Init() = 0;
 		virtual void SwapBuffers() = 0;
+
+		static Scope<GraphicsContext> Create(void* window);
 	};
 
 }

--- a/Hazel/src/Hazel/Renderer/RenderCommand.cpp
+++ b/Hazel/src/Hazel/Renderer/RenderCommand.cpp
@@ -1,10 +1,8 @@
 #include "hzpch.h"
 #include "RenderCommand.h"
 
-#include "Platform/OpenGL/OpenGLRendererAPI.h"
-
 namespace Hazel {
 
-	Scope<RendererAPI> RenderCommand::s_RendererAPI = CreateScope<OpenGLRendererAPI>();
+	Scope<RendererAPI> RenderCommand::s_RendererAPI = RendererAPI::Create();
 
 }

--- a/Hazel/src/Hazel/Renderer/RenderCommand.h
+++ b/Hazel/src/Hazel/Renderer/RenderCommand.h
@@ -27,7 +27,7 @@ namespace Hazel {
 			s_RendererAPI->Clear();
 		}
 
-		inline static void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray)
+		inline static void DrawIndexed(const Ref<VertexArray>& vertexArray)
 		{
 			s_RendererAPI->DrawIndexed(vertexArray);
 		}

--- a/Hazel/src/Hazel/Renderer/Renderer.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer.cpp
@@ -26,7 +26,7 @@ namespace Hazel {
 	{
 	}
 
-	void Renderer::Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<VertexArray>& vertexArray, const glm::mat4& transform)
+	void Renderer::Submit(const std::shared_ptr<Shader>& shader, const Ref<VertexArray>& vertexArray, const glm::mat4& transform)
 	{
 		shader->Bind();
  		std::dynamic_pointer_cast<OpenGLShader>(shader)->UploadUniformMat4("u_ViewProjection", s_SceneData->ViewProjectionMatrix);

--- a/Hazel/src/Hazel/Renderer/Renderer.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer.cpp
@@ -26,7 +26,7 @@ namespace Hazel {
 	{
 	}
 
-	void Renderer::Submit(const std::shared_ptr<Shader>& shader, const Ref<VertexArray>& vertexArray, const glm::mat4& transform)
+	void Renderer::Submit(const Ref<Shader>& shader, const Ref<VertexArray>& vertexArray, const glm::mat4& transform)
 	{
 		shader->Bind();
  		std::dynamic_pointer_cast<OpenGLShader>(shader)->UploadUniformMat4("u_ViewProjection", s_SceneData->ViewProjectionMatrix);

--- a/Hazel/src/Hazel/Renderer/Renderer.h
+++ b/Hazel/src/Hazel/Renderer/Renderer.h
@@ -16,7 +16,7 @@ namespace Hazel {
 		static void BeginScene(OrthographicCamera& camera);
 		static void EndScene();
 
-		static void Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<VertexArray>& vertexArray, const glm::mat4& transform = glm::mat4(1.0f));
+		static void Submit(const std::shared_ptr<Shader>& shader, const Ref<VertexArray>& vertexArray, const glm::mat4& transform = glm::mat4(1.0f));
 
 		inline static RendererAPI::API GetAPI() { return RendererAPI::GetAPI(); }
 	private:

--- a/Hazel/src/Hazel/Renderer/Renderer.h
+++ b/Hazel/src/Hazel/Renderer/Renderer.h
@@ -16,7 +16,7 @@ namespace Hazel {
 		static void BeginScene(OrthographicCamera& camera);
 		static void EndScene();
 
-		static void Submit(const std::shared_ptr<Shader>& shader, const Ref<VertexArray>& vertexArray, const glm::mat4& transform = glm::mat4(1.0f));
+		static void Submit(const Ref<Shader>& shader, const Ref<VertexArray>& vertexArray, const glm::mat4& transform = glm::mat4(1.0f));
 
 		inline static RendererAPI::API GetAPI() { return RendererAPI::GetAPI(); }
 	private:

--- a/Hazel/src/Hazel/Renderer/RendererAPI.cpp
+++ b/Hazel/src/Hazel/Renderer/RendererAPI.cpp
@@ -1,8 +1,22 @@
 #include "hzpch.h"
 #include "RendererAPI.h"
 
+#include "Platform/OpenGL/OpenGLRendererAPI.h"
+
 namespace Hazel {
 
 	RendererAPI::API RendererAPI::s_API = RendererAPI::API::OpenGL;
+
+	Scope<RendererAPI> RendererAPI::Create()
+	{
+		switch (s_API)
+		{
+			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
+			case RendererAPI::API::OpenGL:  return CreateScope<OpenGLRendererAPI>();
+		}
+
+		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");
+		return nullptr;
+	}
 
 }

--- a/Hazel/src/Hazel/Renderer/RendererAPI.h
+++ b/Hazel/src/Hazel/Renderer/RendererAPI.h
@@ -19,7 +19,7 @@ namespace Hazel {
 		virtual void SetClearColor(const glm::vec4& color) = 0;
 		virtual void Clear() = 0;
 
-		virtual void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) = 0;
+		virtual void DrawIndexed(const Ref<VertexArray>& vertexArray) = 0;
 
 		inline static API GetAPI() { return s_API; }
 	private:

--- a/Hazel/src/Hazel/Renderer/RendererAPI.h
+++ b/Hazel/src/Hazel/Renderer/RendererAPI.h
@@ -22,6 +22,8 @@ namespace Hazel {
 		virtual void DrawIndexed(const Ref<VertexArray>& vertexArray) = 0;
 
 		inline static API GetAPI() { return s_API; }
+		static Scope<RendererAPI> Create();
+
 	private:
 		static API s_API;
 	};

--- a/Hazel/src/Hazel/Renderer/Shader.cpp
+++ b/Hazel/src/Hazel/Renderer/Shader.cpp
@@ -11,7 +11,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(filepath);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLShader>(filepath);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");
@@ -23,7 +23,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(name, vertexSrc, fragmentSrc);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLShader>(name, vertexSrc, fragmentSrc);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Texture.cpp
+++ b/Hazel/src/Hazel/Renderer/Texture.cpp
@@ -11,7 +11,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(path);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLTexture2D>(path);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/VertexArray.cpp
+++ b/Hazel/src/Hazel/Renderer/VertexArray.cpp
@@ -6,12 +6,12 @@
 
 namespace Hazel {
 
-	VertexArray* VertexArray::Create()
+	Ref<VertexArray> VertexArray::Create()
 	{
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return new OpenGLVertexArray();
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLVertexArray>();
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/VertexArray.h
+++ b/Hazel/src/Hazel/Renderer/VertexArray.h
@@ -13,10 +13,10 @@ namespace Hazel {
 		virtual void Bind() const = 0;
 		virtual void Unbind() const = 0;
 
-		virtual void AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer) = 0;
+		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) = 0;
 		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) = 0;
 
-		virtual const std::vector<std::shared_ptr<VertexBuffer>>& GetVertexBuffers() const = 0;
+		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const = 0;
 		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const = 0;
 
 		static VertexArray* Create();

--- a/Hazel/src/Hazel/Renderer/VertexArray.h
+++ b/Hazel/src/Hazel/Renderer/VertexArray.h
@@ -19,7 +19,7 @@ namespace Hazel {
 		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const = 0;
 		virtual const Ref<IndexBuffer>& GetIndexBuffer() const = 0;
 
-		static VertexArray* Create();
+		static Ref<VertexArray> Create();
 	};
 
 }

--- a/Hazel/src/Hazel/Renderer/VertexArray.h
+++ b/Hazel/src/Hazel/Renderer/VertexArray.h
@@ -14,10 +14,10 @@ namespace Hazel {
 		virtual void Unbind() const = 0;
 
 		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) = 0;
-		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) = 0;
+		virtual void SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer) = 0;
 
 		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const = 0;
-		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const = 0;
+		virtual const Ref<IndexBuffer>& GetIndexBuffer() const = 0;
 
 		static VertexArray* Create();
 	};

--- a/Hazel/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -26,7 +26,7 @@ namespace Hazel {
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	}
 
-	void OpenGLRendererAPI::DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray)
+	void OpenGLRendererAPI::DrawIndexed(const Ref<VertexArray>& vertexArray)
 	{
 		glDrawElements(GL_TRIANGLES, vertexArray->GetIndexBuffer()->GetCount(), GL_UNSIGNED_INT, nullptr);
 	}

--- a/Hazel/src/Platform/OpenGL/OpenGLRendererAPI.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLRendererAPI.h
@@ -13,7 +13,7 @@ namespace Hazel {
 		virtual void SetClearColor(const glm::vec4& color) override;
 		virtual void Clear() override;
 
-		virtual void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) override;
+		virtual void DrawIndexed(const Ref<VertexArray>& vertexArray) override;
 	};
 
 

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -46,7 +46,7 @@ namespace Hazel {
 		glBindVertexArray(0);
 	}
 
-	void OpenGLVertexArray::AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer)
+	void OpenGLVertexArray::AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer)
 	{
 		HZ_CORE_ASSERT(vertexBuffer->GetLayout().GetElements().size(), "Vertex Buffer has no layout!");
 

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -69,7 +69,7 @@ namespace Hazel {
 		m_VertexBuffers.push_back(vertexBuffer);
 	}
 
-	void OpenGLVertexArray::SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)
+	void OpenGLVertexArray::SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer)
 	{
 		glBindVertexArray(m_RendererID);
 		indexBuffer->Bind();

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
@@ -13,15 +13,15 @@ namespace Hazel {
 		virtual void Bind() const override;
 		virtual void Unbind() const override;
 
-		virtual void AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer) override;
+		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) override;
 		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) override;
 
-		virtual const std::vector<std::shared_ptr<VertexBuffer>>& GetVertexBuffers() const { return m_VertexBuffers; }
+		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const { return m_VertexBuffers; }
 		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const { return m_IndexBuffer; }
 	private:
 		uint32_t m_RendererID;
 		uint32_t m_VertexBufferIndex = 0;
-		std::vector<std::shared_ptr<VertexBuffer>> m_VertexBuffers;
+		std::vector<Ref<VertexBuffer>> m_VertexBuffers;
 		std::shared_ptr<IndexBuffer> m_IndexBuffer;
 	};
 

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
@@ -14,15 +14,15 @@ namespace Hazel {
 		virtual void Unbind() const override;
 
 		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) override;
-		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) override;
+		virtual void SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer) override;
 
 		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const { return m_VertexBuffers; }
-		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const { return m_IndexBuffer; }
+		virtual const Ref<IndexBuffer>& GetIndexBuffer() const { return m_IndexBuffer; }
 	private:
 		uint32_t m_RendererID;
 		uint32_t m_VertexBufferIndex = 0;
 		std::vector<Ref<VertexBuffer>> m_VertexBuffers;
-		std::shared_ptr<IndexBuffer> m_IndexBuffer;
+		Ref<IndexBuffer> m_IndexBuffer;
 	};
 
 }

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -50,8 +50,7 @@ namespace Hazel {
 
 		m_Window = glfwCreateWindow((int)props.Width, (int)props.Height, m_Data.Title.c_str(), nullptr, nullptr);
 
-		m_Context = CreateScope<OpenGLContext>(m_Window);
-
+		m_Context = GraphicsContext::Create(m_Window);
 		m_Context->Init();
 
 		glfwSetWindowUserPointer(m_Window, &m_Data);

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -21,8 +21,7 @@ public:
 			 0.0f,  0.5f, 0.0f, 0.8f, 0.8f, 0.2f, 1.0f
 		};
 
-		Hazel::Ref<Hazel::VertexBuffer> vertexBuffer;
-		vertexBuffer.reset(Hazel::VertexBuffer::Create(vertices, sizeof(vertices)));
+		Hazel::Ref<Hazel::VertexBuffer> vertexBuffer = Hazel::VertexBuffer::Create(vertices, sizeof(vertices));
 		Hazel::BufferLayout layout = {
 			{ Hazel::ShaderDataType::Float3, "a_Position" },
 			{ Hazel::ShaderDataType::Float4, "a_Color" }
@@ -44,8 +43,7 @@ public:
 			-0.5f,  0.5f, 0.0f, 0.0f, 1.0f
 		};
 
-		Hazel::Ref<Hazel::VertexBuffer> squareVB;
-		squareVB.reset(Hazel::VertexBuffer::Create(squareVertices, sizeof(squareVertices)));
+		Hazel::Ref<Hazel::VertexBuffer> squareVB = Hazel::VertexBuffer::Create(squareVertices, sizeof(squareVertices));
 		squareVB->SetLayout({
 			{ Hazel::ShaderDataType::Float3, "a_Position" },
 			{ Hazel::ShaderDataType::Float2, "a_TexCoord" }

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -13,7 +13,7 @@ public:
 	ExampleLayer()
 		: Layer("Example"), m_CameraController(1280.0f / 720.0f)
 	{
-		m_VertexArray.reset(Hazel::VertexArray::Create());
+		m_VertexArray = Hazel::VertexArray::Create();
 
 		float vertices[3 * 7] = {
 			-0.5f, -0.5f, 0.0f, 0.8f, 0.2f, 0.8f, 1.0f,
@@ -33,7 +33,7 @@ public:
 		Hazel::Ref<Hazel::IndexBuffer> indexBuffer = Hazel::IndexBuffer::Create(indices, sizeof(indices) / sizeof(uint32_t));
 		m_VertexArray->SetIndexBuffer(indexBuffer);
 
-		m_SquareVA.reset(Hazel::VertexArray::Create());
+		m_SquareVA = Hazel::VertexArray::Create();
 
 		float squareVertices[5 * 4] = {
 			-0.5f, -0.5f, 0.0f, 0.0f, 0.0f,

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -30,8 +30,7 @@ public:
 		m_VertexArray->AddVertexBuffer(vertexBuffer);
 
 		uint32_t indices[3] = { 0, 1, 2 };
-		Hazel::Ref<Hazel::IndexBuffer> indexBuffer;
-		indexBuffer.reset(Hazel::IndexBuffer::Create(indices, sizeof(indices) / sizeof(uint32_t)));
+		Hazel::Ref<Hazel::IndexBuffer> indexBuffer = Hazel::IndexBuffer::Create(indices, sizeof(indices) / sizeof(uint32_t));
 		m_VertexArray->SetIndexBuffer(indexBuffer);
 
 		m_SquareVA.reset(Hazel::VertexArray::Create());
@@ -51,8 +50,7 @@ public:
 		m_SquareVA->AddVertexBuffer(squareVB);
 
 		uint32_t squareIndices[6] = { 0, 1, 2, 2, 3, 0 };
-		Hazel::Ref<Hazel::IndexBuffer> squareIB;
-		squareIB.reset(Hazel::IndexBuffer::Create(squareIndices, sizeof(squareIndices) / sizeof(uint32_t)));
+		Hazel::Ref<Hazel::IndexBuffer> squareIB = Hazel::IndexBuffer::Create(squareIndices, sizeof(squareIndices) / sizeof(uint32_t));
 		m_SquareVA->SetIndexBuffer(squareIB);
 
 		std::string vertexSrc = R"(


### PR DESCRIPTION
All create functions return refs/scopes instead of raw pointers. This is part of TheCherno/Hazel#140.
This includes:
  - `GraphicsContext`
  - `VertexBuffer`
  - `IndexBuffer`
  - `VertexArray`
  - `Shader`
  - `Texture`
  - `RendererAPI`