### PR TITLE
Added a Macro to automate excluding the Entrypoint

### DIFF
--- a/Hazel/src/Hazel.h
+++ b/Hazel/src/Hazel.h
@@ -28,5 +28,7 @@
 // -----------------------------------
 
 // ---Entry Point---------------------
-#include "Hazel/Core/EntryPoint.h"
+#ifdef __MAIN_FILE__
+  #include "Hazel/Core/EntryPoint.h"
+#endif
 // -----------------------------------

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -1,3 +1,6 @@
+// The __MAIN_FILE__ Macro should be only defined in the file which handles
+// the Application creation (in other words, the file which contains the 'CreateApplication' function)
+#define __MAIN_FILE__
 #include <Hazel.h>
 
 #include "Platform/OpenGL/OpenGLShader.h"


### PR DESCRIPTION
While watching the latest Game Engine Series video I noticed that the cherno just deleted the 'Entrypoint.h' include from 'Hazel.h' and Included it himself in 'Sandbox.cpp', which I thought doesn't looked weird, so I thought of adding this macro, which will make it clearer that this is the main file.
though I think this sounds like a small detail.