### PR TITLE
Made Win-GenProjects.bat work from every directory

### DIFF
--- a/scripts/Win-GenProjects.bat
+++ b/scripts/Win-GenProjects.bat
@@ -1,5 +1,5 @@
 @echo off
-pushd ..\
+pushd %~dp0\..\
 call vendor\bin\premake\premake5.exe vs2019
 popd
 PAUSE


### PR DESCRIPTION
I noticed a little issue with the `Win-GenProjects.bat` script: it assumes that it's ran from the `scripts` directory. It's true if you double click the script from the file explorer, but not if you run it in the terminal from any directory other than `scripts`, in which case, it will crash:
```
C:\dev\Hazel> scripts\Win-GenProjects.bat
The system cannot find the path specified.
Press any key to continue . . .

C:\dev\Hazel>
```
I fixed that by using the parent directory of the script instead of the parent directory of the current directory (`..`). In batch, the constant `%~dp0` holds the absolute path to the batch file, so using `%~dp0\..\` instead of `..\` makes the script work no matter where you run it from.