### PR TITLE
Old code maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin-int/
 **.vcxproj
 **.vcxproj.filters
 **.vcxproj.user
+Sandbox/imgui.ini

--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -20,7 +20,7 @@ namespace Hazel {
 		HZ_CORE_ASSERT(!s_Instance, "Application already exists!");
 		s_Instance = this;
 
-		m_Window = std::unique_ptr<Window>(Window::Create());
+		m_Window = Scope<Window>(Window::Create());
 		m_Window->SetEventCallback(BIND_EVENT_FN(OnEvent));
 
 		Renderer::Init();

--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -57,7 +57,7 @@ namespace Hazel {
 	{
 		while (m_Running)
 		{
-			float time = (float)glfwGetTime();
+			float_t time = (float_t)glfwGetTime();
 			Timestep timestep = time - m_LastFrameTime;
 			m_LastFrameTime = time;
 

--- a/Hazel/src/Hazel/Core/Application.h
+++ b/Hazel/src/Hazel/Core/Application.h
@@ -33,7 +33,7 @@ namespace Hazel {
 		bool OnWindowClose(WindowCloseEvent& e);
 		bool OnWindowResize(WindowResizeEvent& e);
 	private:
-		std::unique_ptr<Window> m_Window;
+		Scope<Window> m_Window;
 		ImGuiLayer* m_ImGuiLayer;
 		bool m_Running = true;
 		bool m_Minimized = false;
@@ -44,6 +44,7 @@ namespace Hazel {
 	};
 
 	// To be defined in CLIENT
-	Application* CreateApplication();
+	Scope<Application> CreateApplication();
+
 
 }

--- a/Hazel/src/Hazel/Core/Application.h
+++ b/Hazel/src/Hazel/Core/Application.h
@@ -38,7 +38,7 @@ namespace Hazel {
 		bool m_Running = true;
 		bool m_Minimized = false;
 		LayerStack m_LayerStack;
-		float m_LastFrameTime = 0.0f;
+		float_t m_LastFrameTime = 0.0f;
 	private:
 		static Application* s_Instance;
 	};

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -8,8 +8,7 @@ int main(int argc, char** argv)
 {
 	Hazel::Log::Init();
 	HZ_CORE_WARN("Initialized Log!");
-	int a = 5;
-	HZ_INFO("Hello! Var={0}", a);
+
 
 	auto app = Hazel::CreateApplication();
 	app->Run();

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -2,17 +2,15 @@
 
 #ifdef HZ_PLATFORM_WINDOWS
 
-extern Hazel::Application* Hazel::CreateApplication();
+extern Hazel::Scope<Hazel::Application> Hazel::CreateApplication();
 
 int main(int argc, char** argv)
 {
 	Hazel::Log::Init();
 	HZ_CORE_WARN("Initialized Log!");
 
-
 	auto app = Hazel::CreateApplication();
 	app->Run();
-	delete app;
 }
 
 #endif

--- a/Hazel/src/Hazel/Core/Input.h
+++ b/Hazel/src/Hazel/Core/Input.h
@@ -15,16 +15,16 @@ namespace Hazel {
 		inline static bool IsKeyPressed(int keycode) { return s_Instance->IsKeyPressedImpl(keycode); }
 
 		inline static bool IsMouseButtonPressed(int button) { return s_Instance->IsMouseButtonPressedImpl(button); }
-		inline static std::pair<float, float> GetMousePosition() { return s_Instance->GetMousePositionImpl(); }
-		inline static float GetMouseX() { return s_Instance->GetMouseXImpl(); }
-		inline static float GetMouseY() { return s_Instance->GetMouseYImpl(); }
+		inline static std::pair<float_t, float_t> GetMousePosition() { return s_Instance->GetMousePositionImpl(); }
+		inline static float_t GetMouseX() { return s_Instance->GetMouseXImpl(); }
+		inline static float_t GetMouseY() { return s_Instance->GetMouseYImpl(); }
 	protected:
 		virtual bool IsKeyPressedImpl(int keycode) = 0;
 
 		virtual bool IsMouseButtonPressedImpl(int button) = 0;
-		virtual std::pair<float, float> GetMousePositionImpl() = 0;
-		virtual float GetMouseXImpl() = 0;
-		virtual float GetMouseYImpl() = 0;
+		virtual std::pair<float_t, float_t> GetMousePositionImpl() = 0;
+		virtual float_t GetMouseXImpl() = 0;
+		virtual float_t GetMouseYImpl() = 0;
 	private:
 		static Scope<Input> s_Instance;
 	};

--- a/Hazel/src/Hazel/Core/LayerStack.h
+++ b/Hazel/src/Hazel/Core/LayerStack.h
@@ -22,7 +22,7 @@ namespace Hazel {
 		std::vector<Layer*>::iterator end() { return m_Layers.end(); }
 	private:
 		std::vector<Layer*> m_Layers;
-		unsigned int m_LayerInsertIndex = 0;
+		uint32_t m_LayerInsertIndex = 0;
 	};
 
 }

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -5,8 +5,8 @@
 
 namespace Hazel {
 
-	std::shared_ptr<spdlog::logger> Log::s_CoreLogger;
-	std::shared_ptr<spdlog::logger> Log::s_ClientLogger;
+	Ref<spdlog::logger> Log::s_CoreLogger;
+	Ref<spdlog::logger> Log::s_ClientLogger;
 
 	void Log::Init()
 	{

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -11,11 +11,11 @@ namespace Hazel {
 	public:
 		static void Init();
 
-		inline static std::shared_ptr<spdlog::logger>& GetCoreLogger() { return s_CoreLogger; }
-		inline static std::shared_ptr<spdlog::logger>& GetClientLogger() { return s_ClientLogger; }
+		inline static Ref<spdlog::logger>& GetCoreLogger() { return s_CoreLogger; }
+		inline static Ref<spdlog::logger>& GetClientLogger() { return s_ClientLogger; }
 	private:
-		static std::shared_ptr<spdlog::logger> s_CoreLogger;
-		static std::shared_ptr<spdlog::logger> s_ClientLogger;
+		static Ref<spdlog::logger> s_CoreLogger;
+		static Ref<spdlog::logger> s_ClientLogger;
 	};
 
 }

--- a/Hazel/src/Hazel/Core/Timestep.h
+++ b/Hazel/src/Hazel/Core/Timestep.h
@@ -5,17 +5,17 @@ namespace Hazel {
 	class Timestep
 	{
 	public:
-		Timestep(float time = 0.0f)
+		Timestep(float_t time = 0.0f)
 			: m_Time(time)
 		{
 		}
 
-		operator float() const { return m_Time; }
+		operator float_t() const { return m_Time; }
 
-		float GetSeconds() const { return m_Time; }
-		float GetMilliseconds() const { return m_Time * 1000.0f; }
+		float_t GetSeconds() const { return m_Time; }
+		float_t GetMilliseconds() const { return m_Time * 1000.0f; }
 	private:
-		float m_Time;
+		float_t m_Time;
 	};
 
 }

--- a/Hazel/src/Hazel/Core/Window.h
+++ b/Hazel/src/Hazel/Core/Window.h
@@ -10,12 +10,12 @@ namespace Hazel {
 	struct WindowProps
 	{
 		std::string Title;
-		unsigned int Width;
-		unsigned int Height;
+		uint32_t Width;
+		uint32_t Height;
 
 		WindowProps(const std::string& title = "Hazel Engine",
-			        unsigned int width = 1280,
-			        unsigned int height = 720)
+		uint32_t width = 1280,
+		uint32_t height = 720)
 			: Title(title), Width(width), Height(height)
 		{
 		}
@@ -31,8 +31,8 @@ namespace Hazel {
 
 		virtual void OnUpdate() = 0;
 
-		virtual unsigned int GetWidth() const = 0;
-		virtual unsigned int GetHeight() const = 0;
+		virtual uint32_t GetWidth() const = 0;
+		virtual uint32_t GetHeight() const = 0;
 
 		// Window attributes
 		virtual void SetEventCallback(const EventCallbackFn& callback) = 0;

--- a/Hazel/src/Hazel/Events/MouseEvent.h
+++ b/Hazel/src/Hazel/Events/MouseEvent.h
@@ -7,11 +7,11 @@ namespace Hazel {
 	class HAZEL_API MouseMovedEvent : public Event
 	{
 	public:
-		MouseMovedEvent(float x, float y)
+		MouseMovedEvent(float_t x, float_t y)
 			: m_MouseX(x), m_MouseY(y) {}
 
-		inline float GetX() const { return m_MouseX; }
-		inline float GetY() const { return m_MouseY; }
+		inline float_t GetX() const { return m_MouseX; }
+		inline float_t GetY() const { return m_MouseY; }
 
 		std::string ToString() const override
 		{
@@ -23,17 +23,17 @@ namespace Hazel {
 		EVENT_CLASS_TYPE(MouseMoved)
 		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
 	private:
-		float m_MouseX, m_MouseY;
+		float_t m_MouseX, m_MouseY;
 	};
 
 	class HAZEL_API MouseScrolledEvent : public Event
 	{
 	public:
-		MouseScrolledEvent(float xOffset, float yOffset)
+		MouseScrolledEvent(float_t xOffset, float_t yOffset)
 			: m_XOffset(xOffset), m_YOffset(yOffset) {}
 
-		inline float GetXOffset() const { return m_XOffset; }
-		inline float GetYOffset() const { return m_YOffset; }
+		inline float_t GetXOffset() const { return m_XOffset; }
+		inline float_t GetYOffset() const { return m_YOffset; }
 
 		std::string ToString() const override
 		{
@@ -45,13 +45,13 @@ namespace Hazel {
 		EVENT_CLASS_TYPE(MouseScrolled)
 		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
 	private:
-		float m_XOffset, m_YOffset;
+		float_t m_XOffset, m_YOffset;
 	};
 
 	class HAZEL_API MouseButtonEvent : public Event
 	{
 	public:
-		inline int GetMouseButton() const { return m_Button; }
+		inline int32_t GetMouseButton() const { return m_Button; }
 
 		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
 	protected:

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.h
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.h
@@ -21,7 +21,7 @@ namespace Hazel {
 		void Begin();
 		void End();
 	private:
-		float m_Time = 0.0f;
+		float_t m_Time = 0.0f;
 	};
 
 }

--- a/Hazel/src/Hazel/Renderer/Buffer.cpp
+++ b/Hazel/src/Hazel/Renderer/Buffer.cpp
@@ -7,24 +7,24 @@
 
 namespace Hazel {
 
-	VertexBuffer* VertexBuffer::Create(float* vertices, uint32_t size)
+	Ref<VertexBuffer> VertexBuffer::Create(float* vertices, uint32_t size)
 	{
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return new OpenGLVertexBuffer(vertices, size);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLVertexBuffer>(vertices, size);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");
 		return nullptr;
 	}
 
-	IndexBuffer* IndexBuffer::Create(uint32_t* indices, uint32_t size)
+	Ref<IndexBuffer> IndexBuffer::Create(uint32_t* indices, uint32_t size)
 	{
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return new OpenGLIndexBuffer(indices, size);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLIndexBuffer>(indices, size);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Buffer.h
+++ b/Hazel/src/Hazel/Renderer/Buffer.h
@@ -111,7 +111,7 @@ namespace Hazel {
 		virtual const BufferLayout& GetLayout() const = 0;
 		virtual void SetLayout(const BufferLayout& layout) = 0;
 
-		static VertexBuffer* Create(float* vertices, uint32_t size);
+		static Ref<VertexBuffer> Create(float* vertices, uint32_t size);
 	};
 
 	class IndexBuffer
@@ -124,7 +124,7 @@ namespace Hazel {
 
 		virtual uint32_t GetCount() const = 0;
 
-		static IndexBuffer* Create(uint32_t* indices, uint32_t size);
+		static Ref<IndexBuffer> Create(uint32_t* indices, uint32_t size);
 	};
 
 }

--- a/Hazel/src/Hazel/Renderer/OrthographicCamera.cpp
+++ b/Hazel/src/Hazel/Renderer/OrthographicCamera.cpp
@@ -5,13 +5,13 @@
 
 namespace Hazel {
 
-	OrthographicCamera::OrthographicCamera(float left, float right, float bottom, float top)
+	OrthographicCamera::OrthographicCamera(float_t left, float_t right, float_t bottom, float_t top)
 		: m_ProjectionMatrix(glm::ortho(left, right, bottom, top, -1.0f, 1.0f)), m_ViewMatrix(1.0f)
 	{
 		m_ViewProjectionMatrix = m_ProjectionMatrix * m_ViewMatrix;
 	}
 
-	void OrthographicCamera::SetProjection(float left, float right, float bottom, float top)
+	void OrthographicCamera::SetProjection(float_t left, float_t right, float_t bottom, float_t top)
 	{
 		m_ProjectionMatrix = glm::ortho(left, right, bottom, top, -1.0f, 1.0f);
 		m_ViewProjectionMatrix = m_ProjectionMatrix * m_ViewMatrix;

--- a/Hazel/src/Hazel/Renderer/OrthographicCamera.h
+++ b/Hazel/src/Hazel/Renderer/OrthographicCamera.h
@@ -7,15 +7,15 @@ namespace Hazel {
 	class OrthographicCamera
 	{
 	public:
-		OrthographicCamera(float left, float right, float bottom, float top);
+		OrthographicCamera(float_t left, float_t right, float_t bottom, float_t top);
 
-		void SetProjection(float left, float right, float bottom, float top);
+		void SetProjection(float_t left, float_t right, float_t bottom, float_t top);
 
 		const glm::vec3& GetPosition() const { return m_Position; }
 		void SetPosition(const glm::vec3& position) { m_Position = position; RecalculateViewMatrix(); }
 
-		float GetRotation() const { return m_Rotation; }
-		void SetRotation(float rotation) { m_Rotation = rotation; RecalculateViewMatrix(); }
+		float_t GetRotation() const { return m_Rotation; }
+		void SetRotation(float_t rotation) { m_Rotation = rotation; RecalculateViewMatrix(); }
 
 		const glm::mat4& GetProjectionMatrix() const { return m_ProjectionMatrix; }
 		const glm::mat4& GetViewMatrix() const { return m_ViewMatrix; }
@@ -28,7 +28,7 @@ namespace Hazel {
 		glm::mat4 m_ViewProjectionMatrix;
 
 		glm::vec3 m_Position = { 0.0f, 0.0f, 0.0f };
-		float m_Rotation = 0.0f;
+		float_t m_Rotation = 0.0f;
 	};
 
 }

--- a/Hazel/src/Hazel/Renderer/OrthographicCameraController.cpp
+++ b/Hazel/src/Hazel/Renderer/OrthographicCameraController.cpp
@@ -6,7 +6,7 @@
 
 namespace Hazel {
 
-	OrthographicCameraController::OrthographicCameraController(float aspectRatio, bool rotation)
+	OrthographicCameraController::OrthographicCameraController(float_t aspectRatio, bool rotation)
 		: m_AspectRatio(aspectRatio), m_Camera(-m_AspectRatio * m_ZoomLevel, m_AspectRatio * m_ZoomLevel, -m_ZoomLevel, m_ZoomLevel), m_Rotation(rotation)
 	{
 	}
@@ -72,7 +72,7 @@ namespace Hazel {
 
 	bool OrthographicCameraController::OnWindowResized(WindowResizeEvent& e)
 	{
-		m_AspectRatio = (float)e.GetWidth() / (float)e.GetHeight();
+		m_AspectRatio = (float_t)e.GetWidth() / (float_t)e.GetHeight();
 		m_Camera.SetProjection(-m_AspectRatio * m_ZoomLevel, m_AspectRatio * m_ZoomLevel, -m_ZoomLevel, m_ZoomLevel);
 		return false;
 	}

--- a/Hazel/src/Hazel/Renderer/OrthographicCameraController.h
+++ b/Hazel/src/Hazel/Renderer/OrthographicCameraController.h
@@ -11,7 +11,7 @@ namespace Hazel {
 	class OrthographicCameraController
 	{
 	public:
-		OrthographicCameraController(float aspectRatio, bool rotation = false);
+		OrthographicCameraController(float_t aspectRatio, bool rotation = false);
 
 		void OnUpdate(Timestep ts);
 		void OnEvent(Event& e);
@@ -19,21 +19,21 @@ namespace Hazel {
 		OrthographicCamera& GetCamera() { return m_Camera; }
 		const OrthographicCamera& GetCamera() const { return m_Camera; }
 
-		float GetZoomLevel() const { return m_ZoomLevel; }
-		void SetZoomLevel(float level) { m_ZoomLevel = level; }
+		float_t GetZoomLevel() const { return m_ZoomLevel; }
+		void SetZoomLevel(float_t level) { m_ZoomLevel = level; }
 	private:
 		bool OnMouseScrolled(MouseScrolledEvent& e);
 		bool OnWindowResized(WindowResizeEvent& e);
 	private:
-		float m_AspectRatio;
-		float m_ZoomLevel = 1.0f;
+		float_t m_AspectRatio;
+		float_t m_ZoomLevel = 1.0f;
 		OrthographicCamera m_Camera;
 
 		bool m_Rotation;
 
 		glm::vec3 m_CameraPosition = { 0.0f, 0.0f, 0.0f };
-		float m_CameraRotation = 0.0f; //In degrees, in the anti-clockwise direction
-		float m_CameraTranslationSpeed = 5.0f, m_CameraRotationSpeed = 180.0f;
+		float_t m_CameraRotation = 0.0f; //In degrees, in the anti-clockwise direction
+		float_t m_CameraTranslationSpeed = 5.0f, m_CameraRotationSpeed = 180.0f;
 	};
 
 }

--- a/Hazel/src/Hazel/Renderer/RenderCommand.h
+++ b/Hazel/src/Hazel/Renderer/RenderCommand.h
@@ -27,7 +27,7 @@ namespace Hazel {
 			s_RendererAPI->Clear();
 		}
 
-		inline static void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray)
+		inline static void DrawIndexed(const Ref<VertexArray>& vertexArray)
 		{
 			s_RendererAPI->DrawIndexed(vertexArray);
 		}

--- a/Hazel/src/Hazel/Renderer/Renderer.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer.cpp
@@ -26,7 +26,7 @@ namespace Hazel {
 	{
 	}
 
-	void Renderer::Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<VertexArray>& vertexArray, const glm::mat4& transform)
+	void Renderer::Submit(const Ref<Shader>& shader, const Ref<VertexArray>& vertexArray, const glm::mat4& transform)
 	{
 		shader->Bind();
  		std::dynamic_pointer_cast<OpenGLShader>(shader)->UploadUniformMat4("u_ViewProjection", s_SceneData->ViewProjectionMatrix);

--- a/Hazel/src/Hazel/Renderer/Renderer.h
+++ b/Hazel/src/Hazel/Renderer/Renderer.h
@@ -16,7 +16,7 @@ namespace Hazel {
 		static void BeginScene(OrthographicCamera& camera);
 		static void EndScene();
 
-		static void Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<VertexArray>& vertexArray, const glm::mat4& transform = glm::mat4(1.0f));
+		static void Submit(const Ref<Shader>& shader, const Ref<VertexArray>& vertexArray, const glm::mat4& transform = glm::mat4(1.0f));
 
 		inline static RendererAPI::API GetAPI() { return RendererAPI::GetAPI(); }
 	private:

--- a/Hazel/src/Hazel/Renderer/RendererAPI.h
+++ b/Hazel/src/Hazel/Renderer/RendererAPI.h
@@ -19,7 +19,7 @@ namespace Hazel {
 		virtual void SetClearColor(const glm::vec4& color) = 0;
 		virtual void Clear() = 0;
 
-		virtual void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) = 0;
+		virtual void DrawIndexed(const Ref<VertexArray>& vertexArray) = 0;
 
 		inline static API GetAPI() { return s_API; }
 	private:

--- a/Hazel/src/Hazel/Renderer/Shader.cpp
+++ b/Hazel/src/Hazel/Renderer/Shader.cpp
@@ -11,7 +11,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(filepath);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLShader>(filepath);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");
@@ -23,7 +23,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLShader>(name, vertexSrc, fragmentSrc);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLShader>(name, vertexSrc, fragmentSrc);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/Texture.cpp
+++ b/Hazel/src/Hazel/Renderer/Texture.cpp
@@ -11,7 +11,7 @@ namespace Hazel {
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return std::make_shared<OpenGLTexture2D>(path);
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLTexture2D>(path);
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/VertexArray.cpp
+++ b/Hazel/src/Hazel/Renderer/VertexArray.cpp
@@ -6,12 +6,12 @@
 
 namespace Hazel {
 
-	VertexArray* VertexArray::Create()
+	Ref<VertexArray> VertexArray::Create()
 	{
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:  return new OpenGLVertexArray();
+			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLVertexArray>();
 		}
 
 		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hazel/src/Hazel/Renderer/VertexArray.h
+++ b/Hazel/src/Hazel/Renderer/VertexArray.h
@@ -13,13 +13,13 @@ namespace Hazel {
 		virtual void Bind() const = 0;
 		virtual void Unbind() const = 0;
 
-		virtual void AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer) = 0;
-		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) = 0;
+		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) = 0;
+		virtual void SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer) = 0;
 
-		virtual const std::vector<std::shared_ptr<VertexBuffer>>& GetVertexBuffers() const = 0;
-		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const = 0;
+		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const = 0;
+		virtual const Ref<IndexBuffer>& GetIndexBuffer() const = 0;
 
-		static VertexArray* Create();
+		static Ref<VertexArray> Create();
 	};
 
 }

--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -9,7 +9,7 @@ namespace Hazel {
 	// VertexBuffer /////////////////////////////////////////////////////////////
 	/////////////////////////////////////////////////////////////////////////////
 
-	OpenGLVertexBuffer::OpenGLVertexBuffer(float* vertices, uint32_t size)
+	OpenGLVertexBuffer::OpenGLVertexBuffer(float_t* vertices, uint32_t size)
 	{
 		glCreateBuffers(1, &m_RendererID);
 		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);

--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.h
@@ -7,7 +7,7 @@ namespace Hazel {
 	class OpenGLVertexBuffer : public VertexBuffer
 	{
 	public:
-		OpenGLVertexBuffer(float* vertices, uint32_t size);
+		OpenGLVertexBuffer(float_t* vertices, uint32_t size);
 		virtual ~OpenGLVertexBuffer();
 
 		virtual void Bind() const override;

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -176,13 +176,13 @@ namespace Hazel {
 		glUseProgram(0);
 	}
 
-	void OpenGLShader::UploadUniformInt(const std::string& name, int value)
+	void OpenGLShader::UploadUniformInt(const std::string& name, int32_t value)
 	{
 		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
 		glUniform1i(location, value);
 	}
 
-	void OpenGLShader::UploadUniformFloat(const std::string& name, float value)
+	void OpenGLShader::UploadUniformFloat(const std::string& name, float_t value)
 	{
 		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
 		glUniform1f(location, value);

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.h
@@ -20,9 +20,9 @@ namespace Hazel {
 
 		virtual const std::string& GetName() const override { return m_Name; }
 
-		void UploadUniformInt(const std::string& name, int value);
+		void UploadUniformInt(const std::string& name, int32_t value);
 
-		void UploadUniformFloat(const std::string& name, float value);
+		void UploadUniformFloat(const std::string& name, float_t value);
 		void UploadUniformFloat2(const std::string& name, const glm::vec2& value);
 		void UploadUniformFloat3(const std::string& name, const glm::vec3& value);
 		void UploadUniformFloat4(const std::string& name, const glm::vec4& value);

--- a/Hazel/src/Platform/Windows/WindowsInput.cpp
+++ b/Hazel/src/Platform/Windows/WindowsInput.cpp
@@ -22,22 +22,22 @@ namespace Hazel {
 		return state == GLFW_PRESS;
 	}
 
-	std::pair<float, float> WindowsInput::GetMousePositionImpl()
+	std::pair<float_t , float_t > WindowsInput::GetMousePositionImpl()
 	{
 		auto window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
 		double xpos, ypos;
 		glfwGetCursorPos(window, &xpos, &ypos);
 
-		return { (float)xpos, (float)ypos };
+		return { (float_t )xpos, (float_t )ypos };
 	}
 
-	float WindowsInput::GetMouseXImpl()
+	float_t WindowsInput::GetMouseXImpl()
 	{
 		auto[x, y] = GetMousePositionImpl();
 		return x;
 	}
 
-	float WindowsInput::GetMouseYImpl()
+	float_t WindowsInput::GetMouseYImpl()
 	{
 		auto[x, y] = GetMousePositionImpl();
 		return y;

--- a/Hazel/src/Platform/Windows/WindowsInput.h
+++ b/Hazel/src/Platform/Windows/WindowsInput.h
@@ -7,12 +7,12 @@ namespace Hazel {
 	class WindowsInput : public Input
 	{
 	protected:
-		virtual bool IsKeyPressedImpl(int keycode) override;
+		virtual bool IsKeyPressedImpl(int32_t keycode) override;
 
-		virtual bool IsMouseButtonPressedImpl(int button) override;
-		virtual std::pair<float, float> GetMousePositionImpl() override;
-		virtual float GetMouseXImpl() override;
-		virtual float GetMouseYImpl() override;
+		virtual bool IsMouseButtonPressedImpl(int32_t button) override;
+		virtual std::pair<float_t, float_t> GetMousePositionImpl() override;
+		virtual float_t GetMouseXImpl() override;
+		virtual float_t GetMouseYImpl() override;
 	};
 
 }

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -48,7 +48,7 @@ namespace Hazel {
 			s_GLFWInitialized = true;
 		}
 
-		m_Window = glfwCreateWindow((int)props.Width, (int)props.Height, m_Data.Title.c_str(), nullptr, nullptr);
+		m_Window = glfwCreateWindow((int32_t)props.Width, (int32_t)props.Height, m_Data.Title.c_str(), nullptr, nullptr);
 
 		m_Context = CreateScope<OpenGLContext>(m_Window);
 
@@ -58,7 +58,7 @@ namespace Hazel {
 		SetVSync(true);
 
 		// Set GLFW callbacks
-		glfwSetWindowSizeCallback(m_Window, [](GLFWwindow* window, int width, int height)
+		glfwSetWindowSizeCallback(m_Window, [](GLFWwindow* window, int32_t width, int32_t height)
 		{
 			WindowData& data = *(WindowData*)glfwGetWindowUserPointer(window);
 			data.Width = width;
@@ -75,7 +75,7 @@ namespace Hazel {
 			data.EventCallback(event);
 		});
 
-		glfwSetKeyCallback(m_Window, [](GLFWwindow* window, int key, int scancode, int action, int mods)
+		glfwSetKeyCallback(m_Window, [](GLFWwindow* window, int32_t key, int32_t scancode, int32_t action, int32_t mods)
 		{
 			WindowData& data = *(WindowData*)glfwGetWindowUserPointer(window);
 
@@ -102,7 +102,7 @@ namespace Hazel {
 			}
 		});
 
-		glfwSetCharCallback(m_Window, [](GLFWwindow* window, unsigned int keycode)
+		glfwSetCharCallback(m_Window, [](GLFWwindow* window, uint32_t keycode)
 		{
 			WindowData& data = *(WindowData*)glfwGetWindowUserPointer(window);
 
@@ -110,7 +110,7 @@ namespace Hazel {
 			data.EventCallback(event);
 		});
 
-		glfwSetMouseButtonCallback(m_Window, [](GLFWwindow* window, int button, int action, int mods)
+		glfwSetMouseButtonCallback(m_Window, [](GLFWwindow* window, int32_t button, int32_t action, int32_t mods)
 		{
 			WindowData& data = *(WindowData*)glfwGetWindowUserPointer(window);
 

--- a/Hazel/src/Platform/Windows/WindowsWindow.h
+++ b/Hazel/src/Platform/Windows/WindowsWindow.h
@@ -15,8 +15,8 @@ namespace Hazel {
 
 		void OnUpdate() override;
 
-		inline unsigned int GetWidth() const override { return m_Data.Width; }
-		inline unsigned int GetHeight() const override { return m_Data.Height; }
+		inline uint32_t GetWidth() const override { return m_Data.Width; }
+		inline uint32_t GetHeight() const override { return m_Data.Height; }
 
 		// Window attributes
 		inline void SetEventCallback(const EventCallbackFn& callback) override { m_Data.EventCallback = callback; }
@@ -34,7 +34,7 @@ namespace Hazel {
 		struct WindowData
 		{
 			std::string Title;
-			unsigned int Width, Height;
+			uint32_t Width, Height;
 			bool VSync;
 
 			EventCallbackFn EventCallback;

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -15,12 +15,14 @@ Size=550,680
 Collapsed=0
 
 [Window][Settings]
-Pos=974,649
+ViewportPos=1128,719
+ViewportId=0x1C33C293
 Size=297,57
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=650,20
+ViewportPos=804,90
+ViewportId=0xE927CF2F
 Size=550,680
 Collapsed=0
 

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -19,5 +19,10 @@ Pos=974,649
 Size=297,57
 Collapsed=0
 
+[Window][Dear ImGui Demo]
+Pos=650,20
+Size=550,680
+Collapsed=0
+
 [Docking][Data]
 

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -13,7 +13,7 @@ public:
 	ExampleLayer()
 		: Layer("Example"), m_CameraController(1280.0f / 720.0f)
 	{
-		m_VertexArray.reset(Hazel::VertexArray::Create());
+		m_VertexArray = (Hazel::VertexArray::Create());
 
 		float vertices[3 * 7] = {
 			-0.5f, -0.5f, 0.0f, 0.8f, 0.2f, 0.8f, 1.0f,
@@ -22,7 +22,7 @@ public:
 		};
 
 		Hazel::Ref<Hazel::VertexBuffer> vertexBuffer;
-		vertexBuffer.reset(Hazel::VertexBuffer::Create(vertices, sizeof(vertices)));
+		vertexBuffer = (Hazel::VertexBuffer::Create(vertices, sizeof(vertices)));
 		Hazel::BufferLayout layout = {
 			{ Hazel::ShaderDataType::Float3, "a_Position" },
 			{ Hazel::ShaderDataType::Float4, "a_Color" }
@@ -32,10 +32,10 @@ public:
 
 		uint32_t indices[3] = { 0, 1, 2 };
 		Hazel::Ref<Hazel::IndexBuffer> indexBuffer;
-		indexBuffer.reset(Hazel::IndexBuffer::Create(indices, sizeof(indices) / sizeof(uint32_t)));
+		indexBuffer = (Hazel::IndexBuffer::Create(indices, sizeof(indices) / sizeof(uint32_t)));
 		m_VertexArray->SetIndexBuffer(indexBuffer);
 
-		m_SquareVA.reset(Hazel::VertexArray::Create());
+		m_SquareVA = (Hazel::VertexArray::Create());
 
 		float squareVertices[5 * 4] = {
 			-0.5f, -0.5f, 0.0f, 0.0f, 0.0f,
@@ -45,7 +45,7 @@ public:
 		};
 
 		Hazel::Ref<Hazel::VertexBuffer> squareVB;
-		squareVB.reset(Hazel::VertexBuffer::Create(squareVertices, sizeof(squareVertices)));
+		squareVB = (Hazel::VertexBuffer::Create(squareVertices, sizeof(squareVertices)));
 		squareVB->SetLayout({
 			{ Hazel::ShaderDataType::Float3, "a_Position" },
 			{ Hazel::ShaderDataType::Float2, "a_TexCoord" }
@@ -54,7 +54,7 @@ public:
 
 		uint32_t squareIndices[6] = { 0, 1, 2, 2, 3, 0 };
 		Hazel::Ref<Hazel::IndexBuffer> squareIB;
-		squareIB.reset(Hazel::IndexBuffer::Create(squareIndices, sizeof(squareIndices) / sizeof(uint32_t)));
+		squareIB = (Hazel::IndexBuffer::Create(squareIndices, sizeof(squareIndices) / sizeof(uint32_t)));
 		m_SquareVA->SetIndexBuffer(squareIB);
 
 		std::string vertexSrc = R"(
@@ -216,7 +216,7 @@ public:
 
 };
 
-Hazel::Application* Hazel::CreateApplication()
+Hazel::Scope<Hazel::Application> Hazel::CreateApplication()
 {
-	return new Sandbox();
+	return Hazel::CreateScope<Sandbox>();
 }


### PR DESCRIPTION
### Old code maintenance and clean up
 1. Replaced all the ints and floats with their corresponding fixed-length int_t and float_t.
 2. Replaced all std::unique_ptr with Hazel::Scope and std::shared_ptr with Hazel::Ref.

### Replaced raw pointers with smart pointers in the following files
1. Buffer.h
> VertexBuffer::Create(); //@return Ref<VertexBuffer>
> IndexBuffer::Create(); //@return Ref<IndexBuffer>

2. Application.h
> Application::Create //@return Scope<Application>
