### PR TITLE
Added file reading sanity check

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -54,11 +54,19 @@ namespace Hazel {
 		if (in)
 		{
 			in.seekg(0, std::ios::end);
-			result.resize(in.tellg());
-			in.seekg(0, std::ios::beg);
-			in.read(&result[0], result.size());
-			in.close();
-;		}
+			size_t size = in.tellg();
+			if (size != -1)
+			{
+				result.resize(size);
+				in.seekg(0, std::ios::beg);
+				in.read(&result[0], size);
+				in.close();
+			}
+			else
+			{
+				HZ_CORE_ERROR("Could not read from file '{0}'", filepath);
+			}
+		}
 		else
 		{
 			HZ_CORE_ERROR("Could not open file '{0}'", filepath);


### PR DESCRIPTION
---
name: 'Added file reading sanity check'
about: Missing fail check in OpenGLShader::ReadFile

---

#### Describe the issue (if no issue has been made)
[std::ifstream::tellg](http://www.cplusplus.com/reference/istream/istream/tellg/) can return -1 on fail, which leads to a fatal memory allocation, as -1 is treated as an unsigned value.
Should print error and return instead.

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Added check on the critical tellg(), so std::string::resize will not be called with -1 anymore. 
Treats this the same way as if the file was missing in the first place.

#### Additional context
Compiles and runs without error on all currently relevant machines (Windows x64).
