### PR TITLE
Premake architecture parameter fix

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -1,5 +1,5 @@
 workspace "Hazel"
-	architecture "x64"
+	architecture "x86_64"
 	startproject "Sandbox"
 
 	configurations


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
This PR doesn't fix any issue.
This PR will correct premake.lua script

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
This PR will correct possible mistake in premake.lua file:

According to [article on premake5 wiki](https://github.com/premake/premake-core/wiki/architecture#parameters) correct architecture parameter for x64 arch is x86_64

#### Additional context
None.
