### PR TITLE
Fixed Instrumentor generating the same start time more than once.

### DIFF
--- a/Hazel/src/Hazel/Debug/Instrumentor.cpp
+++ b/Hazel/src/Hazel/Debug/Instrumentor.cpp
@@ -1,0 +1,3 @@
+#include "hzpch.h"
+#include "Instrumentor.h"
+thread_local long long Hazel::Instrumentor::s_LastTimeStart = 0;

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -137,13 +137,13 @@ namespace Hazel {
 
 #define HZ_PROFILE 1
 #if HZ_PROFILE
-#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
-#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
-#define HZ_PROFILE_SCOPE(name) ::Hazel::InstrumentationTimer timer##__LINE__(name);
-#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(__FUNCSIG__)
+	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
+	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
+	#define HZ_PROFILE_SCOPE(name) ::Hazel::InstrumentationTimer timer##__LINE__(name);
+	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(__FUNCSIG__)
 #else
-#define HZ_PROFILE_BEGIN_SESSION(name, filepath)
-#define HZ_PROFILE_END_SESSION()
-#define HZ_PROFILE_SCOPE(name)
-#define HZ_PROFILE_FUNCTION()
+	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)
+	#define HZ_PROFILE_END_SESSION()
+	#define HZ_PROFILE_SCOPE(name)
+	#define HZ_PROFILE_FUNCTION()
 #endif

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -26,11 +26,10 @@ namespace Hazel {
 		InstrumentationSession* m_CurrentSession;
 		std::ofstream m_OutputStream;
 		int m_ProfileCount;
-		std::mutex m_LastTimeStartMutex;
-		long long m_LastTimeStart;
+		static thread_local long long s_LastTimeStart;
 	public:
 		Instrumentor()
-			: m_CurrentSession(nullptr), m_ProfileCount(0), m_LastTimeStart(0)
+			: m_CurrentSession(nullptr), m_ProfileCount(0)
 		{
 		}
 
@@ -85,11 +84,11 @@ namespace Hazel {
 
 		long long GetNextValidStartTime(long long desiredStartTime)
 		{
-			std::scoped_lock lock(m_LastTimeStartMutex);
-			if (desiredStartTime <= m_LastTimeStart)
-				desiredStartTime = ++m_LastTimeStart;
+	
+			if (desiredStartTime <= s_LastTimeStart)
+				desiredStartTime = ++s_LastTimeStart;
 			else
-				m_LastTimeStart = desiredStartTime;
+				s_LastTimeStart = desiredStartTime;
 			return desiredStartTime;
 		}
 


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The InstrumentationTimer weren't synchronized and multiple of the same start time were generated. This lead to overlapping as seen in https://youtu.be/qiD39bB7DvA?t=1535. 

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Now when starting an InstrumentationTimer it checks and potentially adjusts the starting time a bit, so that no two starting times are identical. This fixes the overlapping:
![trtr](https://user-images.githubusercontent.com/32145627/69419378-9fd4f300-0d1c-11ea-9f83-35e3a8775ba0.png)

#### Additional context
~~I assumed that the Instrumentor will be used from multiple threads. If this is not the case, the mutex can be removed.~~ The mutex is not needed anyway. The thread_local keyword works as well.
 I only tested this on Windows, but there is no platform specific code used.