### PR TITLE
Update OrthographicCameraController.h

### DIFF
--- a/Hazel/src/Hazel/Renderer/OrthographicCameraController.h
+++ b/Hazel/src/Hazel/Renderer/OrthographicCameraController.h
@@ -21,6 +21,11 @@ namespace Hazel {
 
 		float GetZoomLevel() const { return m_ZoomLevel; }
 		void SetZoomLevel(float level) { m_ZoomLevel = level; }
+		
+		const void increasePosition(float x, float y) { m_CameraPosition.x += x; m_CameraPosition.y += y; }
+		const void decreasePosition(float x, float y) { m_CameraPosition.x -= x; m_CameraPosition.y -= y; }
+		const void increaseRotation(float rotation) { m_Rotation += rotation; }
+		const void decreaseRotation(float rotation) { m_Rotation -= rotation; }
 	private:
 		bool OnMouseScrolled(MouseScrolledEvent& e);
 		bool OnWindowResized(WindowResizeEvent& e);


### PR DESCRIPTION
More compact made the movement of the camera.

#### Describe the issue
I just fixed some code in ``OrthographicCamera.h`` and ``OrthographicCamera.cpp``, namely made the camera movement code more compact and readable than it was before. (in my opinion.)

#### Proposed fix 
That is, why always write ``cos(glm:: radians(...))`` and ``sin(glm:: radians(...))`` if it can be much simplified to just ``dX`` and ``dY``. Theta is simply the name of the angle around which the camera will rotate. ``dTranslationSpeed`` and ``dRotationSpeed`` are speeds only multiplied by ``delta``. Well, ``increase*()`` and ``decrease*()`` methods are just auxiliary. (they can not be used, but it seems to me that the code looks cleaner).
