### PR TITLE
make main runloop only accessible on the engine side

### DIFF
--- a/Hazel/src/Hazel/Core/Application.h
+++ b/Hazel/src/Hazel/Core/Application.h
@@ -11,6 +11,8 @@
 
 #include "Hazel/ImGui/ImGuiLayer.h"
 
+int main(int argc, char** argv);
+
 namespace Hazel {
 
 	class Application
@@ -18,8 +20,6 @@ namespace Hazel {
 	public:
 		Application();
 		virtual ~Application();
-
-		void Run();
 
 		void OnEvent(Event& e);
 
@@ -30,6 +30,7 @@ namespace Hazel {
 
 		inline static Application& Get() { return *s_Instance; }
 	private:
+		void Run();
 		bool OnWindowClose(WindowCloseEvent& e);
 		bool OnWindowResize(WindowResizeEvent& e);
 	private:
@@ -41,6 +42,7 @@ namespace Hazel {
 		float m_LastFrameTime = 0.0f;
 	private:
 		static Application* s_Instance;
+		friend int ::main(int argc, char** argv);
 	};
 
 	// To be defined in CLIENT


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Main runloop is currently able to be called by client upon a new Hazel application. This should probably only happen on the engine side since it is called inside the entry point.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Make Run() private and have main() as a friend function of the Application class.

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.
