### PR TITLE
compile time check of window type and input type

### DIFF
--- a/Hazel/src/Hazel/Core/Input.cpp
+++ b/Hazel/src/Hazel/Core/Input.cpp
@@ -1,0 +1,21 @@
+#include "hzpch.h"
+#include "Hazel/Core/Input.h"
+
+#ifdef HZ_PLATFORM_WINDOWS
+	#include "Platform/Windows/WindowsInput.h"
+#endif
+
+namespace Hazel {
+
+	Scope<Input> Input::s_Instance = Input::Create();
+
+	Scope<Input> Input::Create()
+	{
+	#ifdef HZ_PLATFORM_WINDOWS
+		return CreateScope<WindowsInput>();
+	#else
+		HZ_CORE_ASSERT(false, "Unknown platform!");
+		return nullptr;
+	#endif
+	}
+} 

--- a/Hazel/src/Hazel/Core/Input.h
+++ b/Hazel/src/Hazel/Core/Input.h
@@ -20,6 +20,8 @@ namespace Hazel {
 		inline static std::pair<float, float> GetMousePosition() { return s_Instance->GetMousePositionImpl(); }
 		inline static float GetMouseX() { return s_Instance->GetMouseXImpl(); }
 		inline static float GetMouseY() { return s_Instance->GetMouseYImpl(); }
+
+		static Scope<Input> Create();
 	protected:
 		virtual bool IsKeyPressedImpl(KeyCode key) = 0;
 

--- a/Hazel/src/Hazel/Core/Window.cpp
+++ b/Hazel/src/Hazel/Core/Window.cpp
@@ -1,0 +1,15 @@
+#include "hzpch.h"
+
+#include "Window.h"
+
+#ifdef HZ_PLATFORM_WINDOWS
+	#include "Platform/Windows/WindowsWindow.h"
+	namespace Hazel {
+		Scope<Window> Window::Create(const WindowProps& props)
+		{
+			return CreateScope<WindowsWindow>(props);
+	}
+}
+#else
+	#error "Only Windows supported!"
+#endif 

--- a/Hazel/src/Hazel/Core/Window.cpp
+++ b/Hazel/src/Hazel/Core/Window.cpp
@@ -1,15 +1,21 @@
 #include "hzpch.h"
-
-#include "Window.h"
+#include "Hazel/Core/Window.h"
 
 #ifdef HZ_PLATFORM_WINDOWS
 	#include "Platform/Windows/WindowsWindow.h"
-	namespace Hazel {
-		Scope<Window> Window::Create(const WindowProps& props)
-		{
-			return CreateScope<WindowsWindow>(props);
+#endif
+
+namespace Hazel
+{
+
+	Scope<Window> Window::Create(const WindowProps& props)
+	{
+	#ifdef HZ_PLATFORM_WINDOWS
+		return CreateScope<WindowsWindow>(props);
+	#else
+		HZ_CORE_ASSERT(false, "Unknown platform!");
+		return nullptr;
+	#endif
 	}
+
 }
-#else
-	#error "Only Windows supported!"
-#endif 

--- a/Hazel/src/Platform/Windows/WindowsInput.cpp
+++ b/Hazel/src/Platform/Windows/WindowsInput.cpp
@@ -6,8 +6,6 @@
 
 namespace Hazel {
 
-	Scope<Input> Input::s_Instance = CreateScope<WindowsInput>();
-
 	bool WindowsInput::IsKeyPressedImpl(KeyCode key)
 	{
 		auto window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -20,11 +20,6 @@ namespace Hazel {
 		HZ_CORE_ERROR("GLFW Error ({0}): {1}", error, description);
 	}
 
-	Scope<Window> Window::Create(const WindowProps& props)
-	{
-		return CreateScope<WindowsWindow>(props);
-	}
-
 	WindowsWindow::WindowsWindow(const WindowProps& props)
 	{
 		HZ_PROFILE_FUNCTION();


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Window generation does no checks for platform. It would make sense to do this during compile time.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute]
Compile time macro check

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.
