### PR TITLE
fix issue 193

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 **/bin/
 !vendor/bin/premake/
 bin-int/
+
+# Hazel files
 *.log
 
 # Visual Studio files and folder

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/bin/
 !vendor/bin/premake/
 bin-int/
+*.log
 
 # Visual Studio files and folder
 .vs/

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -25,7 +25,6 @@ namespace Hazel {
 		s_ClientLogger = std::make_shared<spdlog::logger>("APP", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_ClientLogger);
 		s_ClientLogger->set_level(spdlog::level::trace);
-
 	}
 
 }

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -1,5 +1,5 @@
 #include "hzpch.h"
-//#include "Hazel/Core/Log.h"		included in hzpch.h already
+#include "Hazel/Core/Log.h"
 
 #include <spdlog/sinks/basic_file_sink.h>
 
@@ -14,11 +14,11 @@ namespace Hazel {
 		s_ConsoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
 
 		std::vector<spdlog::sink_ptr> coreSinks;
-		coreSinks.emplace_back(s_ConsoleSink); // VS debug console
+		coreSinks.emplace_back(s_ConsoleSink);
 		coreSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Core.log", true));
 
 		std::vector<spdlog::sink_ptr> clientSinks;
-		clientSinks.emplace_back(s_ConsoleSink); // VS debug console
+		clientSinks.emplace_back(s_ConsoleSink);
 		clientSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Client.log", true));
 
 		s_CoreLogger = std::make_shared<spdlog::logger>("HAZEL", begin(coreSinks), end(coreSinks));

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -6,37 +6,32 @@
 
 namespace Hazel {
 
-	#ifdef HZ_DEBUG
-		Ref<spdlog::logger> Log::s_CoreDebugLogger;
-		Ref<spdlog::logger> Log::s_ClientDebugLogger;
-	#endif // HZ_DEBUG
+	Ref<spdlog::logger> Log::s_CoreLogger;
+	Ref<spdlog::logger> Log::s_ClientLogger;
 
-	Ref<spdlog::logger> Log::s_CoreFileLogger;
-	Ref<spdlog::logger> Log::s_ClientFileLogger;
 
 	void Log::Init()
 	{
-		#ifdef HZ_DEBUG
-			s_CoreDebugLogger = spdlog::stdout_color_mt("HAZEL");
-			HZ_ASSERT(s_CoreDebugLogger, "Could not initialize Core Debug Logger!");
-			s_CoreDebugLogger->set_pattern("%^[%T]: %v%$");
-			s_CoreDebugLogger->set_level(spdlog::level::trace);
+		// create the sinks
+		std::vector<spdlog::sink_ptr> coreSinks;
+		coreSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>()); // VS debug console
+		coreSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Core.log", true)); // CORE file logger
 
-			s_ClientDebugLogger = spdlog::stdout_color_mt("APP");
-			HZ_ASSERT(s_ClientDebugLogger, "Could not initialize App Debug Logger!");
-			s_ClientDebugLogger->set_pattern("%^[%T]: %v%$");
-			s_ClientDebugLogger->set_level(spdlog::level::trace);
-		#endif // HZ_DEBUG
+		std::vector<spdlog::sink_ptr> clientSinks;
+		clientSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>()); // VS debug console
+		clientSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Client.log", true)); // CLIENT file logger
 
-		s_CoreFileLogger = spdlog::basic_logger_mt("HAZEL-FILE", "hazel-log.txt", true);
-		HZ_ASSERT(s_CoreFileLogger, "Could not initialize Core File Logger!");
-		s_CoreFileLogger->set_pattern("%v");
-		s_CoreFileLogger->set_level(spdlog::level::trace);
+		// create the loggers
+		s_CoreLogger = std::make_shared<spdlog::logger>("HAZEL", begin(coreSinks), end(coreSinks));
+		spdlog::register_logger(s_CoreLogger);
+		s_ClientLogger = std::make_shared<spdlog::logger>("APP", begin(clientSinks), end(clientSinks));
+		spdlog::register_logger(s_ClientLogger);
 
-		s_ClientFileLogger = spdlog::basic_logger_mt("CLIENT-FILE", "client-log.txt", true);
-		HZ_ASSERT(s_ClientFileLogger, "Could not initialize Client File Logger!");
-		s_ClientFileLogger->set_pattern("%v");
-		s_ClientFileLogger->set_level(spdlog::level::trace);
+		// configure the loggers
+		spdlog::set_pattern("%^[%T] %n: %v%$");
+		s_CoreLogger->set_level(spdlog::level::trace);
+		s_ClientLogger->set_level(spdlog::level::trace);
+
 	}
 
 }

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -1,21 +1,43 @@
 #include "hzpch.h"
-#include "Hazel/Core/Log.h"
+//#include "Hazel/Core/Log.h"		included in hzpch.h already
 
 #include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/basic_file_sink.h>
 
 namespace Hazel {
 
-	Ref<spdlog::logger> Log::s_CoreLogger;
-	Ref<spdlog::logger> Log::s_ClientLogger;
+	#ifdef HZ_DEBUG
+		Ref<spdlog::logger> Log::s_CoreDebugLogger;
+		Ref<spdlog::logger> Log::s_ClientDebugLogger;
+	#endif // HZ_DEBUG
+
+	Ref<spdlog::logger> Log::s_CoreFileLogger;
+	Ref<spdlog::logger> Log::s_ClientFileLogger;
 
 	void Log::Init()
 	{
-		spdlog::set_pattern("%^[%T] %n: %v%$");
-		s_CoreLogger = spdlog::stdout_color_mt("HAZEL");
-		s_CoreLogger->set_level(spdlog::level::trace);
+		#ifdef HZ_DEBUG
+			s_CoreDebugLogger = spdlog::stdout_color_mt("HAZEL");
+			HZ_ASSERT(s_CoreDebugLogger, "Could not initialize Core Debug Logger!");
+			s_CoreDebugLogger->set_pattern("%^[%T]: %v%$");
+			s_CoreDebugLogger->set_level(spdlog::level::trace);
 
-		s_ClientLogger = spdlog::stdout_color_mt("APP");
-		s_ClientLogger->set_level(spdlog::level::trace);
+			s_ClientDebugLogger = spdlog::stdout_color_mt("APP");
+			HZ_ASSERT(s_ClientDebugLogger, "Could not initialize App Debug Logger!");
+			s_ClientDebugLogger->set_pattern("%^[%T]: %v%$");
+			s_ClientDebugLogger->set_level(spdlog::level::trace);
+		#endif // HZ_DEBUG
+
+		s_CoreFileLogger = spdlog::basic_logger_mt("HAZEL-FILE", "hazel-log.txt", true);
+		HZ_ASSERT(s_CoreFileLogger, "Could not initialize Core File Logger!");
+		s_CoreFileLogger->set_pattern("%v");
+		s_CoreFileLogger->set_level(spdlog::level::trace);
+
+		s_ClientFileLogger = spdlog::basic_logger_mt("CLIENT-FILE", "client-log.txt", true);
+		HZ_ASSERT(s_ClientFileLogger, "Could not initialize Client File Logger!");
+		s_ClientFileLogger->set_pattern("%v");
+		s_ClientFileLogger->set_level(spdlog::level::trace);
 	}
 
 }
+

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -16,13 +16,13 @@ namespace Hazel {
 		logSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel.log", true));
 
 		logSinks[0]->set_pattern("%^[%T] %n: %v%$");
-		logSinks[1]->set_pattern("%n %L: %v");
+		logSinks[1]->set_pattern("[%l] %n: %v");
 
-		s_CoreLogger = std::make_shared<spdlog::logger>("ENGINE", begin(logSinks), end(logSinks));
+		s_CoreLogger = std::make_shared<spdlog::logger>("HAZEL", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_CoreLogger);
 		s_CoreLogger->set_level(spdlog::level::trace);
 
-		s_ClientLogger = std::make_shared<spdlog::logger>("CLIENT", begin(logSinks), end(logSinks));
+		s_ClientLogger = std::make_shared<spdlog::logger>("APP", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_ClientLogger);
 		s_ClientLogger->set_level(spdlog::level::trace);
 

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -1,33 +1,31 @@
 #include "hzpch.h"
 //#include "Hazel/Core/Log.h"		included in hzpch.h already
 
-#include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/basic_file_sink.h>
 
 namespace Hazel {
 
 	Ref<spdlog::logger> Log::s_CoreLogger;
 	Ref<spdlog::logger> Log::s_ClientLogger;
-
+	Ref<spdlog::sinks::stdout_color_sink_mt> Log::s_ConsoleSink;
 
 	void Log::Init()
 	{
-		// create the sinks
+		s_ConsoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+
 		std::vector<spdlog::sink_ptr> coreSinks;
-		coreSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>()); // VS debug console
-		coreSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Core.log", true)); // CORE file logger
+		coreSinks.emplace_back(s_ConsoleSink); // VS debug console
+		coreSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Core.log", true));
 
 		std::vector<spdlog::sink_ptr> clientSinks;
-		clientSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>()); // VS debug console
-		clientSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Client.log", true)); // CLIENT file logger
+		clientSinks.emplace_back(s_ConsoleSink); // VS debug console
+		clientSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Client.log", true));
 
-		// create the loggers
 		s_CoreLogger = std::make_shared<spdlog::logger>("HAZEL", begin(coreSinks), end(coreSinks));
 		spdlog::register_logger(s_CoreLogger);
 		s_ClientLogger = std::make_shared<spdlog::logger>("APP", begin(clientSinks), end(clientSinks));
 		spdlog::register_logger(s_ClientLogger);
 
-		// configure the loggers
 		spdlog::set_pattern("%^[%T] %n: %v%$");
 		s_CoreLogger->set_level(spdlog::level::trace);
 		s_ClientLogger->set_level(spdlog::level::trace);

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -16,15 +16,17 @@ namespace Hazel {
 		logSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel.log", true));
 
 		logSinks[0]->set_pattern("%^[%T] %n: %v%$");
-		logSinks[1]->set_pattern("[%l] %n: %v");
+		logSinks[1]->set_pattern("[%T] [%l] %n: %v");
 
 		s_CoreLogger = std::make_shared<spdlog::logger>("HAZEL", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_CoreLogger);
 		s_CoreLogger->set_level(spdlog::level::trace);
+		s_CoreLogger->flush_on(spdlog::level::trace);
 
 		s_ClientLogger = std::make_shared<spdlog::logger>("APP", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_ClientLogger);
 		s_ClientLogger->set_level(spdlog::level::trace);
+		s_ClientLogger->flush_on(spdlog::level::trace);
 	}
 
 }

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -12,7 +12,7 @@ namespace Hazel {
 	void Log::Init()
 	{
 		std::vector<spdlog::sink_ptr> logSinks;
-		logSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());// s_ConsoleSink);
+		logSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
 		logSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel.log", true));
 
 		s_CoreLogger = std::make_shared<spdlog::logger>("ENGINE", begin(logSinks), end(logSinks));

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -1,35 +1,32 @@
 #include "hzpch.h"
 #include "Hazel/Core/Log.h"
 
+#include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/basic_file_sink.h>
 
 namespace Hazel {
 
 	Ref<spdlog::logger> Log::s_CoreLogger;
 	Ref<spdlog::logger> Log::s_ClientLogger;
-	Ref<spdlog::sinks::stdout_color_sink_mt> Log::s_ConsoleSink;
 
 	void Log::Init()
 	{
-		s_ConsoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+		std::vector<spdlog::sink_ptr> logSinks;
+		logSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());// s_ConsoleSink);
+		logSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel.log", true));
 
-		std::vector<spdlog::sink_ptr> coreSinks;
-		coreSinks.emplace_back(s_ConsoleSink);
-		coreSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Core.log", true));
-
-		std::vector<spdlog::sink_ptr> clientSinks;
-		clientSinks.emplace_back(s_ConsoleSink);
-		clientSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel-Client.log", true));
-
-		s_CoreLogger = std::make_shared<spdlog::logger>("HAZEL", begin(coreSinks), end(coreSinks));
+		s_CoreLogger = std::make_shared<spdlog::logger>("ENGINE", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_CoreLogger);
-		s_ClientLogger = std::make_shared<spdlog::logger>("APP", begin(clientSinks), end(clientSinks));
+		s_ClientLogger = std::make_shared<spdlog::logger>("CLIENT", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_ClientLogger);
 
-		spdlog::set_pattern("%^[%T] %n: %v%$");
+		s_CoreLogger->sinks()[0]->set_pattern("%^[%T] %n: %v%$");
+		s_CoreLogger->sinks()[1]->set_pattern("%n %L: %v");
 		s_CoreLogger->set_level(spdlog::level::trace);
-		s_ClientLogger->set_level(spdlog::level::trace);
 
+		s_ClientLogger->sinks()[0]->set_pattern("%^[%T] %n: %v%$");
+		s_ClientLogger->sinks()[1]->set_pattern("%n %L: %v");
+		s_ClientLogger->set_level(spdlog::level::trace);
 	}
 
 }

--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -15,18 +15,17 @@ namespace Hazel {
 		logSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
 		logSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("Hazel.log", true));
 
+		logSinks[0]->set_pattern("%^[%T] %n: %v%$");
+		logSinks[1]->set_pattern("%n %L: %v");
+
 		s_CoreLogger = std::make_shared<spdlog::logger>("ENGINE", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_CoreLogger);
-		s_ClientLogger = std::make_shared<spdlog::logger>("CLIENT", begin(logSinks), end(logSinks));
-		spdlog::register_logger(s_ClientLogger);
-
-		s_CoreLogger->sinks()[0]->set_pattern("%^[%T] %n: %v%$");
-		s_CoreLogger->sinks()[1]->set_pattern("%n %L: %v");
 		s_CoreLogger->set_level(spdlog::level::trace);
 
-		s_ClientLogger->sinks()[0]->set_pattern("%^[%T] %n: %v%$");
-		s_ClientLogger->sinks()[1]->set_pattern("%n %L: %v");
+		s_ClientLogger = std::make_shared<spdlog::logger>("CLIENT", begin(logSinks), end(logSinks));
+		spdlog::register_logger(s_ClientLogger);
 		s_ClientLogger->set_level(spdlog::level::trace);
+
 	}
 
 }

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -12,129 +12,25 @@ namespace Hazel {
 	public:
 		static void Init();
 
-		#ifdef HZ_DEBUG
-			inline static Ref<spdlog::logger>& GetCoreDebugLogger() { return s_CoreDebugLogger; }
-			inline static Ref<spdlog::logger>& GetClientDebugLogger() { return s_ClientDebugLogger; }
-		#endif // HZ_DEBUG
-
-		inline static Ref<spdlog::logger>& GetCoreFileLogger() { return s_CoreFileLogger; }
-		inline static Ref<spdlog::logger>& GetClientFileLogger()	{ return s_ClientFileLogger; }
-
+		inline static Ref<spdlog::logger>& GetCoreLogger() { return s_CoreLogger; }
+		inline static Ref<spdlog::logger>& GetClientLogger() { return s_ClientLogger; }
 	private:
-		#ifdef HZ_DEBUG
-			static Ref<spdlog::logger> s_CoreDebugLogger;
-			static Ref<spdlog::logger> s_ClientDebugLogger;
-		#endif // HZ_DEBUG
-
-		static Ref<spdlog::logger> s_CoreFileLogger;
-		static Ref<spdlog::logger> s_ClientFileLogger;
+		static Ref<spdlog::logger> s_CoreLogger;
+		static Ref<spdlog::logger> s_ClientLogger;
 	};
 
 }
 
-#pragma region Core Log Macros
-#ifdef HZ_DEBUG
-#define HZ_CORE_TRACE(...)										\
-			Hazel::Log::GetCoreFileLogger()->trace(__VA_ARGS__);\
-			Hazel::Log::GetCoreFileLogger()->flush();			\
-			Hazel::Log::GetCoreDebugLogger()->trace(__VA_ARGS__)
-#define HZ_CORE_INFO(...)										\
-			Hazel::Log::GetCoreFileLogger()->info(__VA_ARGS__);	\
-			Hazel::Log::GetCoreFileLogger()->flush();			\
-			Hazel::Log::GetCoreDebugLogger()->info(__VA_ARGS__)
-#define HZ_CORE_WARN(...)												\
-			Hazel::Log::GetCoreFileLogger()->warn("\n*** Warning ***");	\
-			Hazel::Log::GetCoreFileLogger()->warn(__VA_ARGS__);			\
-			Hazel::Log::GetCoreFileLogger()->warn("");					\
-			Hazel::Log::GetCoreFileLogger()->flush();					\
-			Hazel::Log::GetCoreDebugLogger()->warn(__VA_ARGS__)
-#define HZ_CORE_ERROR(...)												\
-			Hazel::Log::GetCoreFileLogger()->error("\n*** Error ***");	\
-			Hazel::Log::GetCoreFileLogger()->error(__VA_ARGS__);		\
-			Hazel::Log::GetCoreFileLogger()->error("");					\
-			Hazel::Log::GetCoreFileLogger()->flush();					\
-			Hazel::Log::GetCoreDebugLogger()->error(__VA_ARGS__)
-#define HZ_CORE_CRITICAL(...)												\
-			Hazel::Log::GetCoreFileLogger()->critical("\n*** Critical ***");\
-			Hazel::Log::GetCoreFileLogger()->critical(__VA_ARGS__);			\
-			Hazel::Log::GetCoreFileLogger()->critical("");					\
-			Hazel::Log::GetCoreFileLogger()->flush();						\
-			Hazel::Log::GetCoreDebugLogger()->critical(__VA_ARGS__)
-#elif HZ_RELEASE
-#define HZ_CORE_TRACE(...)										\
-			Hazel::Log::GetCoreFileLogger()->trace(__VA_ARGS__);\
-			Hazel::Log::GetCoreFileLogger()->flush()
-#define HZ_CORE_INFO(...)										\
-			Hazel::Log::GetCoreFileLogger()->info(__VA_ARGS__);	\
-			Hazel::Log::GetCoreFileLogger()->flush()
-#define HZ_CORE_WARN(...)												\
-			Hazel::Log::GetCoreFileLogger()->warn("\n*** Warning ***");	\
-			Hazel::Log::GetCoreFileLogger()->warn(__VA_ARGS__);			\
-			Hazel::Log::GetCoreFileLogger()->warn("");					\
-			Hazel::Log::GetCoreFileLogger()->flush()						
-#define HZ_CORE_ERROR(...)												\
-			Hazel::Log::GetCoreFileLogger()->error("\n*** Error ***");	\
-			Hazel::Log::GetCoreFileLogger()->error(__VA_ARGS__);		\
-			Hazel::Log::GetCoreFileLogger()->error("");					\
-			Hazel::Log::GetCoreFileLogger()->flush()
-#define HZ_CORE_CRITICAL(...)												\
-			Hazel::Log::GetCoreFileLogger()->critical("\n*** Critical ***");\
-			Hazel::Log::GetCoreFileLogger()->critical(__VA_ARGS__);			\
-			Hazel::Log::GetCoreFileLogger()->critical("");					\
-			Hazel::Log::GetCoreFileLogger()->flush()
-#endif
-#pragma endregion
+// Core log macros
+#define HZ_CORE_TRACE(...)    ::Hazel::Log::GetCoreLogger()->trace(__VA_ARGS__)
+#define HZ_CORE_INFO(...)     ::Hazel::Log::GetCoreLogger()->info(__VA_ARGS__)
+#define HZ_CORE_WARN(...)     ::Hazel::Log::GetCoreLogger()->warn(__VA_ARGS__)
+#define HZ_CORE_ERROR(...)    ::Hazel::Log::GetCoreLogger()->error(__VA_ARGS__)
+#define HZ_CORE_CRITICAL(...) ::Hazel::Log::GetCoreLogger()->critical(__VA_ARGS__)
 
-#pragma region Client Log Macros
-#ifdef HZ_DEBUG
-#define HZ_TRACE(...)												\
-			Hazel::Log::GetClientFileLogger()->trace(__VA_ARGS__);	\
-			Hazel::Log::GetClientFileLogger()->flush();				\
-			Hazel::Log::GetClientDebugLogger()->trace(__VA_ARGS__)
-#define HZ_INFO(...)												\
-			Hazel::Log::GetClientFileLogger()->info(__VA_ARGS__);	\
-			Hazel::Log::GetClientFileLogger()->flush();			\
-			Hazel::Log::GetClientDebugLogger()->info(__VA_ARGS__)
-#define HZ_WARN(...)														\
-			Hazel::Log::GetClientFileLogger()->warn("\n*** Warning ***");	\
-			Hazel::Log::GetClientFileLogger()->warn(__VA_ARGS__);			\
-			Hazel::Log::GetClientFileLogger()->warn("");					\
-			Hazel::Log::GetClientFileLogger()->flush();						\
-			Hazel::Log::GetClientDebugLogger()->warn(__VA_ARGS__)
-#define HZ_ERROR(...)													\
-			Hazel::Log::GetClientFileLogger()->error("\n*** Error ***");\
-			Hazel::Log::GetClientFileLogger()->error(__VA_ARGS__);		\
-			Hazel::Log::GetClientFileLogger()->error("");				\
-			Hazel::Log::GetClientFileLogger()->flush();					\
-			Hazel::Log::GetClientDebugLogger()->error(__VA_ARGS__)
-#define HZ_CRITICAL(...)														\
-			Hazel::Log::GetClientFileLogger()->critical("\n*** Critical ***");	\
-			Hazel::Log::GetClientFileLogger()->critical(__VA_ARGS__);			\
-			Hazel::Log::GetClientFileLogger()->critical("");					\
-			Hazel::Log::GetClientFileLogger()->flush();							\
-			Hazel::Log::GetClientDebugLogger()->critical(__VA_ARGS__)
-#elif HZ_RELEASE
-#define HZ_TRACE(...)												\
-			Hazel::Log::GetClientFileLogger()->trace(__VA_ARGS__);	\
-			Hazel::Log::GetClientFileLogger()->flush()
-#define HZ_INFO(...)												\
-			Hazel::Log::GetClientFileLogger()->info(__VA_ARGS__);	\
-			Hazel::Log::GetClientFileLogger()->flush()
-#define HZ_WARN(...)														\
-			Hazel::Log::GetClientFileLogger()->warn("\n*** Warning ***");	\
-			Hazel::Log::GetClientFileLogger()->warn(__VA_ARGS__);			\
-			Hazel::Log::GetClientFileLogger()->warn("");					\
-			Hazel::Log::GetClientFileLogger()->flush()						
-#define HZ_ERROR(...)													\
-			Hazel::Log::GetClientFileLogger()->error("\n*** Error ***");\
-			Hazel::Log::GetClientFileLogger()->error(__VA_ARGS__);		\
-			Hazel::Log::GetClientFileLogger()->error("");				\
-			Hazel::Log::GetClientFileLogger()->flush()
-#define HZ_CRITICAL(...)														\
-			Hazel::Log::GetClientFileLogger()->critical("\n*** Critical ***");	\
-			Hazel::Log::GetClientFileLogger()->critical(__VA_ARGS__);			\
-			Hazel::Log::GetClientFileLogger()->critical("");					\
-			Hazel::Log::GetClientFileLogger()->flush()
-#endif
-#pragma endregion
-
+// Client log macros
+#define HZ_TRACE(...)         ::Hazel::Log::GetClientLogger()->trace(__VA_ARGS__)
+#define HZ_INFO(...)          ::Hazel::Log::GetClientLogger()->info(__VA_ARGS__)
+#define HZ_WARN(...)          ::Hazel::Log::GetClientLogger()->warn(__VA_ARGS__)
+#define HZ_ERROR(...)         ::Hazel::Log::GetClientLogger()->error(__VA_ARGS__)
+#define HZ_CRITICAL(...)      ::Hazel::Log::GetClientLogger()->critical(__VA_ARGS__)

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -4,7 +4,6 @@
 
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace Hazel {
 
@@ -18,7 +17,6 @@ namespace Hazel {
 	private:
 		static Ref<spdlog::logger> s_CoreLogger;
 		static Ref<spdlog::logger> s_ClientLogger;
-		static Ref<spdlog::sinks::stdout_color_sink_mt> s_ConsoleSink;
 	};
 
 }

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -12,25 +12,129 @@ namespace Hazel {
 	public:
 		static void Init();
 
-		inline static Ref<spdlog::logger>& GetCoreLogger() { return s_CoreLogger; }
-		inline static Ref<spdlog::logger>& GetClientLogger() { return s_ClientLogger; }
+		#ifdef HZ_DEBUG
+			inline static Ref<spdlog::logger>& GetCoreDebugLogger() { return s_CoreDebugLogger; }
+			inline static Ref<spdlog::logger>& GetClientDebugLogger() { return s_ClientDebugLogger; }
+		#endif // HZ_DEBUG
+
+		inline static Ref<spdlog::logger>& GetCoreFileLogger() { return s_CoreFileLogger; }
+		inline static Ref<spdlog::logger>& GetClientFileLogger()	{ return s_ClientFileLogger; }
+
 	private:
-		static Ref<spdlog::logger> s_CoreLogger;
-		static Ref<spdlog::logger> s_ClientLogger;
+		#ifdef HZ_DEBUG
+			static Ref<spdlog::logger> s_CoreDebugLogger;
+			static Ref<spdlog::logger> s_ClientDebugLogger;
+		#endif // HZ_DEBUG
+
+		static Ref<spdlog::logger> s_CoreFileLogger;
+		static Ref<spdlog::logger> s_ClientFileLogger;
 	};
 
 }
 
-// Core log macros
-#define HZ_CORE_TRACE(...)    ::Hazel::Log::GetCoreLogger()->trace(__VA_ARGS__)
-#define HZ_CORE_INFO(...)     ::Hazel::Log::GetCoreLogger()->info(__VA_ARGS__)
-#define HZ_CORE_WARN(...)     ::Hazel::Log::GetCoreLogger()->warn(__VA_ARGS__)
-#define HZ_CORE_ERROR(...)    ::Hazel::Log::GetCoreLogger()->error(__VA_ARGS__)
-#define HZ_CORE_CRITICAL(...) ::Hazel::Log::GetCoreLogger()->critical(__VA_ARGS__)
+#pragma region Core Log Macros
+#ifdef HZ_DEBUG
+#define HZ_CORE_TRACE(...)										\
+			Hazel::Log::GetCoreFileLogger()->trace(__VA_ARGS__);\
+			Hazel::Log::GetCoreFileLogger()->flush();			\
+			Hazel::Log::GetCoreDebugLogger()->trace(__VA_ARGS__)
+#define HZ_CORE_INFO(...)										\
+			Hazel::Log::GetCoreFileLogger()->info(__VA_ARGS__);	\
+			Hazel::Log::GetCoreFileLogger()->flush();			\
+			Hazel::Log::GetCoreDebugLogger()->info(__VA_ARGS__)
+#define HZ_CORE_WARN(...)												\
+			Hazel::Log::GetCoreFileLogger()->warn("\n*** Warning ***");	\
+			Hazel::Log::GetCoreFileLogger()->warn(__VA_ARGS__);			\
+			Hazel::Log::GetCoreFileLogger()->warn("");					\
+			Hazel::Log::GetCoreFileLogger()->flush();					\
+			Hazel::Log::GetCoreDebugLogger()->warn(__VA_ARGS__)
+#define HZ_CORE_ERROR(...)												\
+			Hazel::Log::GetCoreFileLogger()->error("\n*** Error ***");	\
+			Hazel::Log::GetCoreFileLogger()->error(__VA_ARGS__);		\
+			Hazel::Log::GetCoreFileLogger()->error("");					\
+			Hazel::Log::GetCoreFileLogger()->flush();					\
+			Hazel::Log::GetCoreDebugLogger()->error(__VA_ARGS__)
+#define HZ_CORE_CRITICAL(...)												\
+			Hazel::Log::GetCoreFileLogger()->critical("\n*** Critical ***");\
+			Hazel::Log::GetCoreFileLogger()->critical(__VA_ARGS__);			\
+			Hazel::Log::GetCoreFileLogger()->critical("");					\
+			Hazel::Log::GetCoreFileLogger()->flush();						\
+			Hazel::Log::GetCoreDebugLogger()->critical(__VA_ARGS__)
+#elif HZ_RELEASE
+#define HZ_CORE_TRACE(...)										\
+			Hazel::Log::GetCoreFileLogger()->trace(__VA_ARGS__);\
+			Hazel::Log::GetCoreFileLogger()->flush()
+#define HZ_CORE_INFO(...)										\
+			Hazel::Log::GetCoreFileLogger()->info(__VA_ARGS__);	\
+			Hazel::Log::GetCoreFileLogger()->flush()
+#define HZ_CORE_WARN(...)												\
+			Hazel::Log::GetCoreFileLogger()->warn("\n*** Warning ***");	\
+			Hazel::Log::GetCoreFileLogger()->warn(__VA_ARGS__);			\
+			Hazel::Log::GetCoreFileLogger()->warn("");					\
+			Hazel::Log::GetCoreFileLogger()->flush()						
+#define HZ_CORE_ERROR(...)												\
+			Hazel::Log::GetCoreFileLogger()->error("\n*** Error ***");	\
+			Hazel::Log::GetCoreFileLogger()->error(__VA_ARGS__);		\
+			Hazel::Log::GetCoreFileLogger()->error("");					\
+			Hazel::Log::GetCoreFileLogger()->flush()
+#define HZ_CORE_CRITICAL(...)												\
+			Hazel::Log::GetCoreFileLogger()->critical("\n*** Critical ***");\
+			Hazel::Log::GetCoreFileLogger()->critical(__VA_ARGS__);			\
+			Hazel::Log::GetCoreFileLogger()->critical("");					\
+			Hazel::Log::GetCoreFileLogger()->flush()
+#endif
+#pragma endregion
 
-// Client log macros
-#define HZ_TRACE(...)         ::Hazel::Log::GetClientLogger()->trace(__VA_ARGS__)
-#define HZ_INFO(...)          ::Hazel::Log::GetClientLogger()->info(__VA_ARGS__)
-#define HZ_WARN(...)          ::Hazel::Log::GetClientLogger()->warn(__VA_ARGS__)
-#define HZ_ERROR(...)         ::Hazel::Log::GetClientLogger()->error(__VA_ARGS__)
-#define HZ_CRITICAL(...)      ::Hazel::Log::GetClientLogger()->critical(__VA_ARGS__)
+#pragma region Client Log Macros
+#ifdef HZ_DEBUG
+#define HZ_TRACE(...)												\
+			Hazel::Log::GetClientFileLogger()->trace(__VA_ARGS__);	\
+			Hazel::Log::GetClientFileLogger()->flush();				\
+			Hazel::Log::GetClientDebugLogger()->trace(__VA_ARGS__)
+#define HZ_INFO(...)												\
+			Hazel::Log::GetClientFileLogger()->info(__VA_ARGS__);	\
+			Hazel::Log::GetClientFileLogger()->flush();			\
+			Hazel::Log::GetClientDebugLogger()->info(__VA_ARGS__)
+#define HZ_WARN(...)														\
+			Hazel::Log::GetClientFileLogger()->warn("\n*** Warning ***");	\
+			Hazel::Log::GetClientFileLogger()->warn(__VA_ARGS__);			\
+			Hazel::Log::GetClientFileLogger()->warn("");					\
+			Hazel::Log::GetClientFileLogger()->flush();						\
+			Hazel::Log::GetClientDebugLogger()->warn(__VA_ARGS__)
+#define HZ_ERROR(...)													\
+			Hazel::Log::GetClientFileLogger()->error("\n*** Error ***");\
+			Hazel::Log::GetClientFileLogger()->error(__VA_ARGS__);		\
+			Hazel::Log::GetClientFileLogger()->error("");				\
+			Hazel::Log::GetClientFileLogger()->flush();					\
+			Hazel::Log::GetClientDebugLogger()->error(__VA_ARGS__)
+#define HZ_CRITICAL(...)														\
+			Hazel::Log::GetClientFileLogger()->critical("\n*** Critical ***");	\
+			Hazel::Log::GetClientFileLogger()->critical(__VA_ARGS__);			\
+			Hazel::Log::GetClientFileLogger()->critical("");					\
+			Hazel::Log::GetClientFileLogger()->flush();							\
+			Hazel::Log::GetClientDebugLogger()->critical(__VA_ARGS__)
+#elif HZ_RELEASE
+#define HZ_TRACE(...)												\
+			Hazel::Log::GetClientFileLogger()->trace(__VA_ARGS__);	\
+			Hazel::Log::GetClientFileLogger()->flush()
+#define HZ_INFO(...)												\
+			Hazel::Log::GetClientFileLogger()->info(__VA_ARGS__);	\
+			Hazel::Log::GetClientFileLogger()->flush()
+#define HZ_WARN(...)														\
+			Hazel::Log::GetClientFileLogger()->warn("\n*** Warning ***");	\
+			Hazel::Log::GetClientFileLogger()->warn(__VA_ARGS__);			\
+			Hazel::Log::GetClientFileLogger()->warn("");					\
+			Hazel::Log::GetClientFileLogger()->flush()						
+#define HZ_ERROR(...)													\
+			Hazel::Log::GetClientFileLogger()->error("\n*** Error ***");\
+			Hazel::Log::GetClientFileLogger()->error(__VA_ARGS__);		\
+			Hazel::Log::GetClientFileLogger()->error("");				\
+			Hazel::Log::GetClientFileLogger()->flush()
+#define HZ_CRITICAL(...)														\
+			Hazel::Log::GetClientFileLogger()->critical("\n*** Critical ***");	\
+			Hazel::Log::GetClientFileLogger()->critical(__VA_ARGS__);			\
+			Hazel::Log::GetClientFileLogger()->critical("");					\
+			Hazel::Log::GetClientFileLogger()->flush()
+#endif
+#pragma endregion
+

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -4,6 +4,7 @@
 
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace Hazel {
 
@@ -17,6 +18,7 @@ namespace Hazel {
 	private:
 		static Ref<spdlog::logger> s_CoreLogger;
 		static Ref<spdlog::logger> s_ClientLogger;
+		static Ref<spdlog::sinks::stdout_color_sink_mt> s_ConsoleSink;
 	};
 
 }

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -45,7 +45,7 @@ namespace Hazel {
 				// Subsequent profiling output meant for the original session will end up in the
 				// newly opened session instead.  That's better than having badly formatted
 				// profiling output.
-				if (Log::GetCoreLogger()) { // Edge case: BeginSession() might be before Log::Init()
+				if (Log::GetCoreFileLogger()) { // Edge case: BeginSession() might be before Log::Init()
 					HZ_CORE_ERROR("Instrumentor::BeginSession('{0}') when session '{1}' already open.", name, m_CurrentSession->Name);
 				}
 				InternalEndSession();
@@ -56,7 +56,7 @@ namespace Hazel {
 				m_CurrentSession = new InstrumentationSession({name});
 				WriteHeader();
 			} else {
-				if (Log::GetCoreLogger()) { // Edge case: BeginSession() might be before Log::Init()
+				if (Log::GetCoreFileLogger()) { // Edge case: BeginSession() might be before Log::Init()
 					HZ_CORE_ERROR("Instrumentor could not open results file '{0}'.", filepath);
 				}
 			}

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -45,7 +45,7 @@ namespace Hazel {
 				// Subsequent profiling output meant for the original session will end up in the
 				// newly opened session instead.  That's better than having badly formatted
 				// profiling output.
-				if (Log::GetCoreFileLogger()) { // Edge case: BeginSession() might be before Log::Init()
+				if (Log::GetCoreLogger()) { // Edge case: BeginSession() might be before Log::Init()
 					HZ_CORE_ERROR("Instrumentor::BeginSession('{0}') when session '{1}' already open.", name, m_CurrentSession->Name);
 				}
 				InternalEndSession();
@@ -56,7 +56,7 @@ namespace Hazel {
 				m_CurrentSession = new InstrumentationSession({name});
 				WriteHeader();
 			} else {
-				if (Log::GetCoreFileLogger()) { // Edge case: BeginSession() might be before Log::Init()
+				if (Log::GetCoreLogger()) { // Edge case: BeginSession() might be before Log::Init()
 					HZ_CORE_ERROR("Instrumentor could not open results file '{0}'.", filepath);
 				}
 			}


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
As stated in Issue #193 there is a need for the implementation of file loggers.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Closes #193
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
I implemented a file logger for both Hazel Core and Hazel Client.
The Hazel Core file logger will create a file named "hazel-log.txt".
The Client file logger will create a file named "client-log.txt".

The console loggers will only be available in Debug builds while the file loggers will be available in Debug and Release builds.

NOTE:
I changed an if-statement in Instrumentor.h --- It now checks if the file logger is initialized.

#### Additional context
I tested and ran both Debug and Release build at it seems to work like a charm