### PR TITLE
added script to get/update submodules

### DIFF
--- a/scripts/Win-GetSubmodules.bat
+++ b/scripts/Win-GetSubmodules.bat
@@ -1,0 +1,5 @@
+@ECHO OFF
+pushd %~dp0\..\
+git submodule update --init --recursive
+popd
+PAUSE


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
No issue at all - just a little script to make it easier for the user to get the submodules after cloning the repository or to lookup updates for the submodules.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
No issue - just a little feature for the users convenience getting/updating the submodules of Hazel.
The script is called "Win-GetSubmodules" and resides right next to "Win-GenProjects" inside the scripts folder