### PR TITLE
Fixed memory leak in LayerStack

### DIFF
--- a/Hazel/src/Hazel/Core/LayerStack.cpp
+++ b/Hazel/src/Hazel/Core/LayerStack.cpp
@@ -30,6 +30,7 @@ namespace Hazel {
 		{
 			layer->OnDetach();
 			m_Layers.erase(it);
+			delete layer;
 			m_LayerInsertIndex--;
 		}
 	}
@@ -40,6 +41,7 @@ namespace Hazel {
 		if (it != m_Layers.end())
 		{
 			overlay->OnDetach();
+			delete overlay;
 			m_Layers.erase(it);
 		}
 	}


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
When we pop a layer or an overlay the layer/overlay will get removed from the layer stack but they won't get deleted when the destructor of the layer stack is called (because obviously they are not on the layer stack anymore).

#### Proposed fix 
Delete the layer/overlay inside PopLayer/PopOverlay functions.

#### Additional context
I talked with @TheCherno about this issue back in october 2019 already and here is what he said:

"Cherno 15.10.2019
Just took a look at the layer stack issue... yes, delete should definitely be called from LayerStack::PopLayer
And PopOverlay"