### PR TITLE
fixing ImGUI not swallowing mouse & key input

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -9,6 +9,8 @@
 
 #include <glfw/glfw3.h>
 
+#include <imgui.h>
+
 namespace Hazel {
 
 	Application* Application::s_Instance = nullptr;
@@ -58,6 +60,12 @@ namespace Hazel {
 		EventDispatcher dispatcher(e);
 		dispatcher.Dispatch<WindowCloseEvent>(HZ_BIND_EVENT_FN(Application::OnWindowClose));
 		dispatcher.Dispatch<WindowResizeEvent>(HZ_BIND_EVENT_FN(Application::OnWindowResize));
+
+		ImGuiIO& io = ImGui::GetIO();
+		if (io.WantCaptureMouse)
+		{
+			e.Handled = true;
+		}
 
 		for (auto it = m_LayerStack.rbegin(); it != m_LayerStack.rend(); ++it)
 		{

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
@@ -69,6 +69,10 @@ namespace Hazel {
 		ImGui_ImplOpenGL3_NewFrame();
 		ImGui_ImplGlfw_NewFrame();
 		ImGui::NewFrame();
+
+		// this is just added to test the behaviour
+		bool showDemo = true;
+		ImGui::ShowDemoWindow(&showDemo);
 	}
 
 	void ImGuiLayer::End()

--- a/Hazel/src/Hazel/Renderer/OrthographicCameraController.cpp
+++ b/Hazel/src/Hazel/Renderer/OrthographicCameraController.cpp
@@ -4,6 +4,8 @@
 #include "Hazel/Core/Input.h"
 #include "Hazel/Core/KeyCodes.h"
 
+#include <imgui.h>
+
 namespace Hazel {
 
 	OrthographicCameraController::OrthographicCameraController(float aspectRatio, bool rotation)
@@ -15,41 +17,46 @@ namespace Hazel {
 	{
 		HZ_PROFILE_FUNCTION();
 
-		if (Input::IsKeyPressed(HZ_KEY_A))
-		{
-			m_CameraPosition.x -= cos(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
-			m_CameraPosition.y -= sin(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
-		}
-		else if (Input::IsKeyPressed(HZ_KEY_D))
-		{
-			m_CameraPosition.x += cos(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
-			m_CameraPosition.y += sin(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
-		}
+		ImGuiIO& io = ImGui::GetIO();
 
-		if (Input::IsKeyPressed(HZ_KEY_W))
+		if (!io.WantCaptureKeyboard)
 		{
-			m_CameraPosition.x += -sin(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
-			m_CameraPosition.y += cos(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
-		}
-		else if (Input::IsKeyPressed(HZ_KEY_S))
-		{
-			m_CameraPosition.x -= -sin(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
-			m_CameraPosition.y -= cos(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
-		}
+			if (Input::IsKeyPressed(HZ_KEY_A))
+			{
+				m_CameraPosition.x -= cos(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
+				m_CameraPosition.y -= sin(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
+			}
+			else if (Input::IsKeyPressed(HZ_KEY_D))
+			{
+				m_CameraPosition.x += cos(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
+				m_CameraPosition.y += sin(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
+			}
 
-		if (m_Rotation)
-		{
-			if (Input::IsKeyPressed(HZ_KEY_Q))
-				m_CameraRotation += m_CameraRotationSpeed * ts;
-			if (Input::IsKeyPressed(HZ_KEY_E))
-				m_CameraRotation -= m_CameraRotationSpeed * ts;
+			if (Input::IsKeyPressed(HZ_KEY_W))
+			{
+				m_CameraPosition.x += -sin(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
+				m_CameraPosition.y += cos(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
+			}
+			else if (Input::IsKeyPressed(HZ_KEY_S))
+			{
+				m_CameraPosition.x -= -sin(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
+				m_CameraPosition.y -= cos(glm::radians(m_CameraRotation)) * m_CameraTranslationSpeed * ts;
+			}
 
-			if (m_CameraRotation > 180.0f)
-				m_CameraRotation -= 360.0f;
-			else if (m_CameraRotation <= -180.0f)
-				m_CameraRotation += 360.0f;
+			if (m_Rotation)
+			{
+				if (Input::IsKeyPressed(HZ_KEY_Q))
+					m_CameraRotation += m_CameraRotationSpeed * ts;
+				if (Input::IsKeyPressed(HZ_KEY_E))
+					m_CameraRotation -= m_CameraRotationSpeed * ts;
 
-			m_Camera.SetRotation(m_CameraRotation);
+				if (m_CameraRotation > 180.0f)
+					m_CameraRotation -= 360.0f;
+				else if (m_CameraRotation <= -180.0f)
+					m_CameraRotation += 360.0f;
+
+				m_Camera.SetRotation(m_CameraRotation);
+			}
 		}
 
 		m_Camera.SetPosition(m_CameraPosition);

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -19,5 +19,10 @@ Pos=974,649
 Size=297,57
 Collapsed=0
 
+[Window][Dear ImGui Demo]
+Pos=650,20
+Size=550,680
+Collapsed=0
+
 [Docking][Data]
 


### PR DESCRIPTION
this fixes the mouse scrolling bug inside issue #200 but doesn't close the issue.

i've been playing with around with fixing the keyinput issue but didn't come to any solution yet.

The problem with the key input issue lies within our OrthographicCameraController which checks for pressed keys inside its OnUpdate() function.

I tried solving that by moving the key input checks from there to an OnKeyPressed() function. 
That works nice so far and ImGUI swallows those inputs, too. But new issues come up then:

- as long as an ImGUI window is active (focused) it will swallow key inputs and they won't get forwarded to the camera - even if you don't type into a textbox
- we don't have access to timestep inside the OnKeyPressed() function .. thus the camera movement looks very clunky and not as smooth as we do it right now inside the OnUpdate() function of the OrthographicCameraController.

I am open for hints and tipps on how to solve the key input issue.