### PR TITLE
Exposed Window Props to the sandbox application

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -13,13 +13,13 @@ namespace Hazel {
 
 	Application* Application::s_Instance = nullptr;
 
-	Application::Application()
+	Application::Application(const WindowProps& props)
 	{
 		HZ_PROFILE_FUNCTION();
 
 		HZ_CORE_ASSERT(!s_Instance, "Application already exists!");
 		s_Instance = this;
-		m_Window = Window::Create();
+		m_Window = Window::Create(props);
 		m_Window->SetEventCallback(HZ_BIND_EVENT_FN(Application::OnEvent));
 
 		Renderer::Init();

--- a/Hazel/src/Hazel/Core/Application.h
+++ b/Hazel/src/Hazel/Core/Application.h
@@ -18,7 +18,7 @@ namespace Hazel {
 	class Application
 	{
 	public:
-		Application();
+		Application(const WindowProps& props);
 		virtual ~Application();
 
 		void OnEvent(Event& e);

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -7,7 +7,8 @@
 class Sandbox : public Hazel::Application
 {
 public:
-	Sandbox()
+	Sandbox(const Hazel::WindowProps& props)
+		:Application(props)
 	{
 		// PushLayer(new ExampleLayer());
 		PushLayer(new Sandbox2D());
@@ -20,5 +21,5 @@ public:
 
 Hazel::Application* Hazel::CreateApplication()
 {
-	return new Sandbox();
+	return new Sandbox({ "Sandbox - Hazel" });
 }


### PR DESCRIPTION
Application could not change the name of the window without changing the default window Props.

#### Proposed fix

Expose the window props through the application constructor 