### PR TITLE
Fix minor issues in OpenGL buffer creation

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -49,8 +49,11 @@ namespace Hazel {
 		HZ_PROFILE_FUNCTION();
 
 		glCreateBuffers(1, &m_RendererID);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
+		
+		// GL_ELEMENT_ARRAY_BUFFER is not valid without an actively bound VAO
+		// Binding with GL_ARRAY_BUFFER allows the data to be loaded regardless of VAO state. 
+		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+		glBufferData(GL_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
 	}
 
 	OpenGLIndexBuffer::~OpenGLIndexBuffer()

--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -15,7 +15,7 @@ namespace Hazel {
 
 		glCreateBuffers(1, &m_RendererID);
 		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ARRAY_BUFFER, size, vertices, GL_STATIC_DRAW);
+		glBufferData(GL_ARRAY_BUFFER, size * sizeof(float), vertices, GL_STATIC_DRAW);
 	}
 
 	OpenGLVertexBuffer::~OpenGLVertexBuffer()
@@ -49,8 +49,8 @@ namespace Hazel {
 		HZ_PROFILE_FUNCTION();
 
 		glCreateBuffers(1, &m_RendererID);
-		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
 	}
 
 	OpenGLIndexBuffer::~OpenGLIndexBuffer()

--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -15,7 +15,7 @@ namespace Hazel {
 
 		glCreateBuffers(1, &m_RendererID);
 		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ARRAY_BUFFER, size * sizeof(float), vertices, GL_STATIC_DRAW);
+		glBufferData(GL_ARRAY_BUFFER, size, vertices, GL_STATIC_DRAW);
 	}
 
 	OpenGLVertexBuffer::~OpenGLVertexBuffer()


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
In OpenGLBuffer.cpp I noticed the following issues:
 - The vertex buffer reports it's size in bytes as the vertex count, and not count * sizeof(float)
 - ~~The constructor of OpenGLIndexBuffer used GL_ARRAY_BUFFER instead of GL_ELEMENT_ARRAY_BUFFER like it does in the same object's Bind() and Unbind() functions.~~

#### PR impact 
Issues this solves: closes #184 

#### Proposed fix
- [ ] Change OpenGLVertexBuffer to report the correct buffer size
- [ ] ~~Change OpenGLIndexBuffer to bind the correct buffer type in its constructor.~~ *Not bug

#### Additional context

