### PR TITLE
General Cleanup

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -7,7 +7,7 @@
 
 #include "Hazel/Core/Input.h"
 
-#include <glfw/glfw3.h>
+#include <GLFW/glfw3.h>
 
 namespace Hazel {
 

--- a/Hazel/src/Hazel/Core/Core.h
+++ b/Hazel/src/Hazel/Core/Core.h
@@ -50,6 +50,8 @@
 		#error "Platform doesn't support debugbreak yet!"
 	#endif
 	#define HZ_ENABLE_ASSERTS
+#else
+	#define HZ_DEBUGBREAK()
 #endif
 
 #ifdef HZ_ENABLE_ASSERTS

--- a/Hazel/src/Hazel/Core/Core.h
+++ b/Hazel/src/Hazel/Core/Core.h
@@ -48,8 +48,12 @@
 #endif
 
 #ifdef HZ_ENABLE_ASSERTS
-	#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
-	#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
+	#ifdef HZ_PLATFORM_WINDWOS
+		#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
+		#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
+	#else
+		#error "Platform doesn't support asserts yet!"
+	#endif
 #else
 	#define HZ_ASSERT(x, ...)
 	#define HZ_CORE_ASSERT(x, ...)

--- a/Hazel/src/Hazel/Core/Core.h
+++ b/Hazel/src/Hazel/Core/Core.h
@@ -44,8 +44,11 @@
 #endif // End of platform detection
 
 #ifdef HZ_DEBUG
-	#ifdef HZ_PLATFORM_WINDOWS
+	#if defined(HZ_PLATFORM_WINDOWS)
 		#define HZ_DEBUGBREAK() __debugbreak()
+	#elif defined(HZ_PLATFORM_LINUX)
+		#include <signal.h>
+		#define HZ_DEBUGBREAK() raise(SIGTRAP)
 	#else
 		#error "Platform doesn't support debugbreak yet!"
 	#endif

--- a/Hazel/src/Hazel/Core/Core.h
+++ b/Hazel/src/Hazel/Core/Core.h
@@ -44,16 +44,17 @@
 #endif // End of platform detection
 
 #ifdef HZ_DEBUG
+	#ifdef HZ_PLATFORM_WINDOWS
+		#define HZ_DEBUGBREAK() __debugbreak()
+	#else
+		#error "Platform doesn't support debugbreak yet!"
+	#endif
 	#define HZ_ENABLE_ASSERTS
 #endif
 
 #ifdef HZ_ENABLE_ASSERTS
-	#ifdef HZ_PLATFORM_WINDWOS
-		#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
-		#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
-	#else
-		#error "Platform doesn't support asserts yet!"
-	#endif
+		#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
+		#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
 #else
 	#define HZ_ASSERT(x, ...)
 	#define HZ_CORE_ASSERT(x, ...)

--- a/Hazel/src/Hazel/Core/Core.h
+++ b/Hazel/src/Hazel/Core/Core.h
@@ -53,8 +53,8 @@
 #endif
 
 #ifdef HZ_ENABLE_ASSERTS
-		#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
-		#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
+	#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
+	#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
 #else
 	#define HZ_ASSERT(x, ...)
 	#define HZ_CORE_ASSERT(x, ...)

--- a/Hazel/src/Platform/OpenGL/OpenGLContext.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLContext.cpp
@@ -3,7 +3,6 @@
 
 #include <GLFW/glfw3.h>
 #include <glad/glad.h>
-#include <GL/GL.h>
 
 namespace Hazel {
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -84,7 +84,6 @@ project "Hazel"
 
 		defines
 		{
-			"HZ_BUILD_DLL"
 		}
 
 	filter "configurations:Debug"

--- a/premake5.lua
+++ b/premake5.lua
@@ -56,7 +56,8 @@ project "Hazel"
 
 	defines
 	{
-		"_CRT_SECURE_NO_WARNINGS"
+		"_CRT_SECURE_NO_WARNINGS",
+		"GLFW_INCLUDE_NONE"
 	}
 
 	includedirs
@@ -83,8 +84,7 @@ project "Hazel"
 
 		defines
 		{
-			"HZ_BUILD_DLL",
-			"GLFW_INCLUDE_NONE"
+			"HZ_BUILD_DLL"
 		}
 
 	filter "configurations:Debug"


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Cleanup for multiple thing:
- GLFW_INCLUDE_NONE was defined only for Windows, though it isn't a Windows exclusive issue.
=> Moved to global defines.
- Removed obsolete `HZ_BUILD_DLL` define
- In 'OpenGLContext.cpp' the header file `GL/GL.h` isn't used, but yet is included. - Removed.
- Includes should match the case of files included. In this cast the GLFW directory is all uppercase.
=> Modified to fit directory name.
- __debugbreak is an Windows exclusive function.
=> Wrapped it in `HZ_DEBUGBREAK` macro with an appropriate ifdef statement for windows and added the linux equivalent.
=> `HZ_ASSERT` is now platform agnostic.

EDIT by @LovelySanta: Making PR description up to date