### PR TITLE
Index count selection fixed in OpenGLRendererAPI

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -60,7 +60,7 @@ namespace Hazel {
 
 	void OpenGLRendererAPI::DrawIndexed(const Ref<VertexArray>& vertexArray, uint32_t indexCount)
 	{
-		uint32_t count = indexCount ? vertexArray->GetIndexBuffer()->GetCount() : indexCount;
+		uint32_t count = indexCount ? indexCount : vertexArray->GetIndexBuffer()->GetCount();
 		glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, nullptr);
 		glBindTexture(GL_TEXTURE_2D, 0);
 	}


### PR DESCRIPTION
Sides in the ternary operator for indexCount seem to be permutated.
The indexCount parameter should be used if its value is larger than 0.
