### PR TITLE
Added flush when textures exceed max texture slots

### DIFF
--- a/Hazel/src/Hazel/Renderer/Renderer2D.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer2D.cpp
@@ -214,6 +214,9 @@ namespace Hazel {
 
 		if (textureIndex == 0.0f)
 		{
+			if (s_Data.TextureSlotIndex >= Renderer2DData::MaxTextureSlots)
+				FlushAndReset();
+
 			textureIndex = (float)s_Data.TextureSlotIndex;
 			s_Data.TextureSlots[s_Data.TextureSlotIndex] = texture;
 			s_Data.TextureSlotIndex++;
@@ -301,6 +304,9 @@ namespace Hazel {
 
 		if (textureIndex == 0.0f)
 		{
+			if (s_Data.TextureSlotIndex >= Renderer2DData::MaxTextureSlots)
+				FlushAndReset();
+
 			textureIndex = (float)s_Data.TextureSlotIndex;
 			s_Data.TextureSlots[s_Data.TextureSlotIndex] = texture;
 			s_Data.TextureSlotIndex++;


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Can't render more than Renderer2DData::MaxTextureSlots different textures.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Resolves #214 
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Flush the current batch when a new texture slot is required and they all are occupied.

#### Additional context
As a quick test I've added the cherno logo instead of the checkerboard to the rotating quad. I've also set the max textures to 2 (flat color + 1 other) in order to test this flush behaviour. The results are shown on the screenshot below.

On the left side you see the reference statistics, where `Renderer2DData::MaxTextureSlots = 32`. This draws everything in 2 draw calls, as there are 2 scenes. On the right side, I've set `Renderer2DData::MaxTextureSlots = 2`, so in the first scene it will draw the colored quads and the checkerboard textured one in 1 draw call and it will draw the rotating cherno textured one in a 2nd draw call. The 3rd draw call is for the other scene.

![image](https://user-images.githubusercontent.com/26593477/79746153-d170db00-8309-11ea-99ed-29f756709103.png)

