### PR TITLE
Imgui Swallowing

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -63,8 +63,7 @@ namespace Hazel {
 		{
 			if (e.Handled) 
 				break;
-			else
-				(*it)->OnEvent(e);
+			(*it)->OnEvent(e);
 		}
 	}
 

--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -61,9 +61,10 @@ namespace Hazel {
 
 		for (auto it = m_LayerStack.rbegin(); it != m_LayerStack.rend(); ++it)
 		{
-			(*it)->OnEvent(e);
-			if (e.Handled)
+			if (e.Handled) 
 				break;
+			else
+				(*it)->OnEvent(e);
 		}
 	}
 

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
@@ -61,6 +61,13 @@ namespace Hazel {
 		ImGui_ImplGlfw_Shutdown();
 		ImGui::DestroyContext();
 	}
+
+	void ImGuiLayer::OnEvent(Event& e)
+	{
+		ImGuiIO& io = ImGui::GetIO();
+		e.Handled |= e.IsInCategory(EventCategoryMouse) & io.WantCaptureMouse;
+		e.Handled |= e.IsInCategory(EventCategoryKeyboard) & io.WantCaptureKeyboard;
+	}
 	
 	void ImGuiLayer::Begin()
 	{

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.h
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.h
@@ -16,6 +16,7 @@ namespace Hazel {
 
 		virtual void OnAttach() override;
 		virtual void OnDetach() override;
+		virtual void OnEvent(Event& e) override;
 
 		void Begin();
 		void End();


### PR DESCRIPTION
#### Describe the issue
ImGui sometimes wants mouse and/or key inputs, when it does,
stop events from reaching the rest of the layers.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       |  Closes #200 
Other PRs this solves    | #201

#### Proposed fix
Provide an OnEvent function for ImGui, so it can set events to handled when it wants input.

#### Additional context
This is not the complete solution to #201.
