### PR TITLE
Fixed warning

### DIFF
--- a/Hazel/src/Hazel/Renderer/Renderer2D.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer2D.cpp
@@ -125,7 +125,7 @@ namespace Hazel {
 	{
 		HZ_PROFILE_FUNCTION();
 
-		uint32_t dataSize = (uint8_t*)s_Data.QuadVertexBufferPtr - (uint8_t*)s_Data.QuadVertexBufferBase;
+		uint32_t dataSize = (uint32_t)( (uint8_t*)s_Data.QuadVertexBufferPtr - (uint8_t*)s_Data.QuadVertexBufferBase );
 		s_Data.QuadVertexBuffer->SetData(s_Data.QuadVertexBufferBase, dataSize);
 
 		Flush();


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
When ending the scene in Renderer2D, we substract `uint8_t*` pointers to know the dataSize in bytes. The result of this is a `ptrdiff_t`, which is an alias for a 64 bit wide signed integer on 64 bit systems. While assigning this to the dataSize - a `uint32_t` - there is a warning due to possible loss of data during this implicit cast, as shown in the image below.

![image](https://user-images.githubusercontent.com/26593477/80213660-cc799780-8639-11ea-8a34-bf288f4aa4c9.png)

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None 
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Explicit cast this to uint32_t to prevent the implicit casting and such preventing the warning message.

#### Additional context
Did a clean build, now it is not prompting the warning anymore, works as intended.