### PR TITLE
delete QuadVertexBufferBase on shutdown

### DIFF
--- a/Hazel/src/Hazel/Renderer/Renderer2D.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer2D.cpp
@@ -106,6 +106,8 @@ namespace Hazel {
 	void Renderer2D::Shutdown()
 	{
 		HZ_PROFILE_FUNCTION();
+
+		delete s_Data.QuadVertexBufferBase;
 	}
 
 	void Renderer2D::BeginScene(const OrthographicCamera& camera)

--- a/Hazel/src/Hazel/Renderer/Renderer2D.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer2D.cpp
@@ -107,7 +107,7 @@ namespace Hazel {
 	{
 		HZ_PROFILE_FUNCTION();
 
-		delete s_Data.QuadVertexBufferBase;
+		delete[] s_Data.QuadVertexBufferBase;
 	}
 
 	void Renderer2D::BeginScene(const OrthographicCamera& camera)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
s_Data.QuadVertexBufferBase is allocated in Init, but isn't deleted on Shutdown.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Delete s_Data.QuadVertexBufferBase in the Shutdown method.