### PR TITLE
cmake support

### DIFF
--- a/Hazel/CMakeLists.txt
+++ b/Hazel/CMakeLists.txt
@@ -1,0 +1,103 @@
+cmake_minimum_required(VERSION 3.16)
+project(Hazel)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_compile_definitions(HZ_DEBUG)
+
+include_directories(vendor/spdlog/include)
+include_directories(vendor/Glad/include)
+include_directories(vendor/GLFW/include)
+include_directories(vendor/imgui)
+include_directories(vendor/stb_image)
+include_directories(vendor/glm)
+
+add_subdirectory(vendor/glm)
+add_subdirectory(vendor/GLFW)
+
+set(IMGUI_SRC
+        vendor/imgui/imgui.h
+        vendor/imgui/imgui.cpp
+        vendor/imgui/imgui_widgets.cpp
+        vendor/imgui/imgui_demo.cpp
+        vendor/imgui/imgui_draw.cpp)
+
+set(STBIMG_SRC
+        vendor/stb_image/stb_image.cpp)
+
+set(GLAD_SRC
+        vendor/Glad/src/glad.c)
+
+set(SOURCES
+        src/Hazel/Core/Application.cpp
+        src/Hazel/Core/Application.h
+        src/Hazel/Core/Core.h
+        src/Hazel/Core/EntryPoint.h
+        src/Hazel/Core/Input.cpp
+        src/Hazel/Core/Input.h
+        src/Hazel/Core/KeyCodes.h
+        src/Hazel/Core/Layer.cpp
+        src/Hazel/Core/Layer.h
+        src/Hazel/Core/LayerStack.cpp
+        src/Hazel/Core/LayerStack.h
+        src/Hazel/Core/Log.cpp
+        src/Hazel/Core/Log.h
+        src/Hazel/Core/MouseCodes.h
+        src/Hazel/Core/Timestep.h
+        src/Hazel/Core/Window.cpp
+        src/Hazel/Core/Window.h
+        src/Hazel/Debug/Instrumentor.h
+        src/Hazel/Events/ApplicationEvent.h
+        src/Hazel/Events/Event.h
+        src/Hazel/Events/KeyEvent.h
+        src/Hazel/Events/MouseEvent.h
+        src/Hazel/ImGui/ImGuiBuild.cpp
+        src/Hazel/ImGui/ImGuiLayer.cpp
+        src/Hazel/ImGui/ImGuiLayer.h
+        src/Hazel/Renderer/Buffer.cpp
+        src/Hazel/Renderer/Buffer.h
+        src/Hazel/Renderer/GraphicsContext.cpp
+        src/Hazel/Renderer/GraphicsContext.h
+        src/Hazel/Renderer/OrthographicCamera.cpp
+        src/Hazel/Renderer/OrthographicCamera.h
+        src/Hazel/Renderer/OrthographicCameraController.cpp
+        src/Hazel/Renderer/OrthographicCameraController.h
+        src/Hazel/Renderer/RenderCommand.cpp
+        src/Hazel/Renderer/RenderCommand.h
+        src/Hazel/Renderer/Renderer.cpp
+        src/Hazel/Renderer/Renderer.h
+        src/Hazel/Renderer/Renderer2D.cpp
+        src/Hazel/Renderer/Renderer2D.h
+        src/Hazel/Renderer/RendererAPI.cpp
+        src/Hazel/Renderer/RendererAPI.h
+        src/Hazel/Renderer/Shader.cpp
+        src/Hazel/Renderer/Shader.h
+        src/Hazel/Renderer/Texture.cpp
+        src/Hazel/Renderer/Texture.h
+        src/Hazel/Renderer/VertexArray.cpp
+        src/Hazel/Renderer/VertexArray.h
+        src/Platform/OpenGL/OpenGLBuffer.cpp
+        src/Platform/OpenGL/OpenGLBuffer.h
+        src/Platform/OpenGL/OpenGLContext.cpp
+        src/Platform/OpenGL/OpenGLContext.h
+        src/Platform/OpenGL/OpenGLRendererAPI.cpp
+        src/Platform/OpenGL/OpenGLRendererAPI.h
+        src/Platform/OpenGL/OpenGLShader.cpp
+        src/Platform/OpenGL/OpenGLShader.h
+        src/Platform/OpenGL/OpenGLTexture.cpp
+        src/Platform/OpenGL/OpenGLTexture.h
+        src/Platform/OpenGL/OpenGLVertexArray.cpp
+        src/Platform/OpenGL/OpenGLVertexArray.h
+        src/Platform/Windows/WindowsInput.cpp
+        src/Platform/Windows/WindowsInput.h
+        src/Platform/Windows/WindowsWindow.cpp
+        src/Platform/Windows/WindowsWindow.h
+        src/Hazel.h
+        src/hzpch.cpp
+        src/hzpch.h)
+
+include_directories(src)
+
+add_library(${PROJECT_NAME} STATIC ${SOURCES} ${IMGUI_SRC} ${GLAD_SRC} ${STBIMG_SRC})
+
+target_link_libraries(${PROJECT_NAME} glfw)

--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -7,7 +7,7 @@
 
 #include "Hazel/Core/Input.h"
 
-#include <glfw/glfw3.h>
+#include <GLFW/glfw3.h>
 
 namespace Hazel {
 

--- a/Hazel/src/Hazel/Core/Core.h
+++ b/Hazel/src/Hazel/Core/Core.h
@@ -37,7 +37,6 @@
 	#error "Android is not supported!"
 #elif defined(__linux__)
 	#define HZ_PLATFORM_LINUX
-	#error "Linux is not supported!"
 #else
 	/* Unknown compiler/platform */
 	#error "Unknown platform!"
@@ -48,8 +47,15 @@
 #endif
 
 #ifdef HZ_ENABLE_ASSERTS
-	#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
-	#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
+
+    #ifdef _MSC_VER
+        #define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
+        #define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); __debugbreak(); } }
+    #else
+        #define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); } }
+        #define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); } }
+    #endif
+
 #else
 	#define HZ_ASSERT(x, ...)
 	#define HZ_CORE_ASSERT(x, ...)

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Hazel/Core/Core.h"
 
-#ifdef HZ_PLATFORM_WINDOWS
+#if defined(HZ_PLATFORM_WINDOWS) || defined(HZ_PLATFORM_LINUX)
 
 extern Hazel::Application* Hazel::CreateApplication();
 

--- a/Hazel/src/Hazel/Core/Input.cpp
+++ b/Hazel/src/Hazel/Core/Input.cpp
@@ -1,7 +1,7 @@
 #include "hzpch.h"
 #include "Hazel/Core/Input.h"
 
-#ifdef HZ_PLATFORM_WINDOWS
+#if defined(HZ_PLATFORM_WINDOWS) || defined(HZ_PLATFORM_LINUX)
 	#include "Platform/Windows/WindowsInput.h"
 #endif
 
@@ -11,7 +11,7 @@ namespace Hazel {
 
 	Scope<Input> Input::Create()
 	{
-	#ifdef HZ_PLATFORM_WINDOWS
+	#if defined(HZ_PLATFORM_WINDOWS) || defined(HZ_PLATFORM_LINUX)
 		return CreateScope<WindowsInput>();
 	#else
 		HZ_CORE_ASSERT(false, "Unknown platform!");

--- a/Hazel/src/Hazel/Core/Window.cpp
+++ b/Hazel/src/Hazel/Core/Window.cpp
@@ -1,7 +1,7 @@
 #include "hzpch.h"
 #include "Hazel/Core/Window.h"
 
-#ifdef HZ_PLATFORM_WINDOWS
+#if defined(HZ_PLATFORM_WINDOWS) || defined(HZ_PLATFORM_LINUX)
 	#include "Platform/Windows/WindowsWindow.h"
 #endif
 
@@ -10,7 +10,7 @@ namespace Hazel
 
 	Scope<Window> Window::Create(const WindowProps& props)
 	{
-	#ifdef HZ_PLATFORM_WINDOWS
+	#if defined(HZ_PLATFORM_WINDOWS) || defined(HZ_PLATFORM_LINUX)
 		return CreateScope<WindowsWindow>(props);
 	#else
 		HZ_CORE_ASSERT(false, "Unknown platform!");

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
@@ -8,8 +8,8 @@
 #include "Hazel/Core/Application.h"
 
 // TEMPORARY
-#include <GLFW/glfw3.h>
 #include <glad/glad.h>
+#include <GLFW/glfw3.h>
 
 namespace Hazel {
 

--- a/Hazel/src/Platform/OpenGL/OpenGLContext.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLContext.cpp
@@ -1,9 +1,9 @@
 #include "hzpch.h"
 #include "Platform/OpenGL/OpenGLContext.h"
 
-#include <GLFW/glfw3.h>
 #include <glad/glad.h>
-#include <GL/GL.h>
+#include <GLFW/glfw3.h>
+#include <GL/gl.h>
 
 namespace Hazel {
 

--- a/Sandbox/CMakeLists.txt
+++ b/Sandbox/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.16)
+project(Sandbox)
+
+set(CMAKE_CXX_STANDARD 17)
+
+include_directories(../Hazel/vendor/spdlog/include)
+include_directories(../Hazel/vendor/Glad/include)
+include_directories(../Hazel/vendor/GLFW/include)
+include_directories(../Hazel/vendor/imgui)
+include_directories(../Hazel/vendor/stb_image)
+include_directories(../Hazel/vendor/glm)
+
+include_directories(../Hazel/src)
+
+set(SOURCES
+        src/ExampleLayer.cpp
+        src/ExampleLayer.h
+        src/Sandbox2D.cpp
+        src/Sandbox2D.h
+        src/SandboxApp.cpp)
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME} Hazel)

--- a/Sandbox/src/ExampleLayer.cpp
+++ b/Sandbox/src/ExampleLayer.cpp
@@ -1,6 +1,6 @@
 #include "ExampleLayer.h"
 
-#include "imgui/imgui.h"
+#include <imgui.h>
 
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>

--- a/Sandbox/src/Sandbox2D.cpp
+++ b/Sandbox/src/Sandbox2D.cpp
@@ -1,5 +1,5 @@
 #include "Sandbox2D.h"
-#include <imgui/imgui.h>
+#include <imgui.h>
 
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>


### PR DESCRIPTION
cmake support
linux support

Engine tested on Ubuntu 20.04.
Vendor: X.Org
Renderer: AMD Radeon (TM) RX 460 Graphics (POLARIS11, DRM 3.35.0, 5.4.0-28-generic, LLVM 9.0.1)
Version: 4.6 (Compatibility Profile) Mesa 20.2.0-devel (git-f1a40a2 2020-05-03 focal-oibaf-ppa)

There are some bad minor changes:
File: Sandbox/src/ExampleLayer.cpp -> changed include path
Sandbox/src/Sandbox2D.cpp -> changed include path

Other changes shouldn't break legacy.