### PR TITLE
fixed the '__cdecl' output in Instrumentor.h in a 'constexpr' way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ bin-int/
 
 # Hazel files
 *.log
-HazelProfile-Startup.json
-HazelProfile-Runtime.json
-HazelProfile-Shutdown.json
 
 # Visual Studio files and folder
 .vs/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ bin-int/
 
 # Hazel files
 *.log
+HazelProfile-Startup.json
+HazelProfile-Runtime.json
+HazelProfile-Shutdown.json
 
 # Visual Studio files and folder
 .vs/

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -144,9 +144,7 @@ namespace Hazel {
 		~InstrumentationTimer()
 		{
 			if (!m_Stopped)
-			{
 				Stop();
-			}
 		}
 
 		void Stop()
@@ -173,26 +171,20 @@ namespace Hazel {
 			char Data[N];
 		};
 
-		template <size_t N>
-		constexpr auto RemoveCdecl(const char(&expr)[N])
+		template <size_t N, size_t K>
+		constexpr auto CleanupOutputString(const char(&expr)[N], const char(&remove)[K])
 		{
-			ChangeResult<N> result;
+			ChangeResult<N> result = {};
 
 			size_t srcIndex = 0;
 			size_t dstIndex = 0;
 			while (srcIndex < N - 2)
 			{
-				if (expr[srcIndex] == '_' &&
-					expr[srcIndex + 1] == '_' &&
-					expr[srcIndex + 2] == 'c' &&
-					expr[srcIndex + 3] == 'd' &&
-					expr[srcIndex + 4] == 'e' &&
-					expr[srcIndex + 5] == 'c' &&
-					expr[srcIndex + 6] == 'l' &&
-					expr[srcIndex + 7] == ' ')
-				{
-					srcIndex += 8;
-				}
+				size_t matchIndex = 0;
+				while (matchIndex < K - 1 && srcIndex + matchIndex < N - 1 && expr[srcIndex + matchIndex] == remove[matchIndex])
+					matchIndex++;
+				if (matchIndex == K - 1)
+					srcIndex += matchIndex;
 				result.Data[dstIndex++] = expr[srcIndex++];
 			}
 			result.Data[dstIndex++] = expr[N - 2];
@@ -219,7 +211,7 @@ namespace Hazel {
 	}
 }
 
-#define HZ_PROFILE 0
+#define HZ_PROFILE 1
 #if HZ_PROFILE
 	// Resolve which function signature macro will be used. Note that this only
 	// is resolved when the (pre)compiler starts, so the syntax highlighting
@@ -229,7 +221,7 @@ namespace Hazel {
 	#elif defined(__DMC__) && (__DMC__ >= 0x810)
 		#define HZ_FUNC_SIG __PRETTY_FUNCTION__
 	#elif (defined(__FUNCSIG__) || (_MSC_VER))
-		#define HZ_FUNC_SIG ::Hazel::InstrumentorUtils::RemoveCdecl(__FUNCSIG__).Data
+		#define HZ_FUNC_SIG ::Hazel::InstrumentorUtils::CleanupOutputString(__FUNCSIG__, "__cdecl ").Data
 	#elif (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 600)) || (defined(__IBMCPP__) && (__IBMCPP__ >= 500))
 		#define HZ_FUNC_SIG __FUNCTION__
 	#elif defined(__BORLANDC__) && (__BORLANDC__ >= 0x550)

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -219,7 +219,7 @@ namespace Hazel {
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
 	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
 	#define HZ_PROFILE_SCOPE(name) constexpr auto fixedName = ::Hazel::InstrumentorUtils::CleanupOutputString(name, "__cdecl ");\
-									::Hazel::InstrumentationTimer timer##__LINE__(fixedName.Data);
+									::Hazel::InstrumentationTimer timer##__LINE__(fixedName.Data)
 	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(HZ_FUNC_SIG)
 #else
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -211,7 +211,7 @@ namespace Hazel {
 	}
 }
 
-#define HZ_PROFILE 1
+#define HZ_PROFILE 0
 #if HZ_PROFILE
 	// Resolve which function signature macro will be used. Note that this only
 	// is resolved when the (pre)compiler starts, so the syntax highlighting

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -9,6 +9,38 @@
 
 namespace Hazel {
 
+	template <size_t N>
+	struct fixed_string {
+		char data[N];
+//		size_t size;
+	};
+
+	template <size_t N>
+	constexpr auto clean_expression(const char(&expr)[N]) {
+		fixed_string<N> result = {};
+
+		int src_idx = 0;
+		int dst_idx = 0;
+		while (src_idx < N - 2) {
+			if (expr[src_idx]     == '_' &&
+				expr[src_idx + 1] == '_' &&
+				expr[src_idx + 2] == 'c' &&
+				expr[src_idx + 3] == 'd' &&
+				expr[src_idx + 4] == 'e' &&
+				expr[src_idx + 5] == 'c' &&
+				expr[src_idx + 6] == 'l' &&
+				expr[src_idx + 7] == ' ')
+			{
+				src_idx += 8;
+			}
+			result.data[dst_idx++] = expr[src_idx++];
+		}
+		result.data[dst_idx++] = expr[N - 2];
+		result.data[dst_idx++] = expr[N - 1];
+//		result.size = dst_idx;
+		return result;
+	}
+
 	using FloatingPointMicroseconds = std::chrono::duration<double, std::micro>;
 
 	struct ProfileResult
@@ -157,7 +189,7 @@ namespace Hazel {
 	};
 }
 
-#define HZ_PROFILE 0
+#define HZ_PROFILE 1
 #if HZ_PROFILE
 	// Resolve which function signature macro will be used. Note that this only
 	// is resolved when the (pre)compiler starts, so the syntax highlighting
@@ -166,7 +198,7 @@ namespace Hazel {
 		#define HZ_FUNC_SIG __PRETTY_FUNCTION__
 	#elif defined(__DMC__) && (__DMC__ >= 0x810)
 		#define HZ_FUNC_SIG __PRETTY_FUNCTION__
-	#elif defined(__FUNCSIG__)
+	#elif defined(_MSC_VER)
 		#define HZ_FUNC_SIG __FUNCSIG__
 	#elif (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 600)) || (defined(__IBMCPP__) && (__IBMCPP__ >= 500))
 		#define HZ_FUNC_SIG __FUNCTION__
@@ -183,7 +215,7 @@ namespace Hazel {
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
 	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
 	#define HZ_PROFILE_SCOPE(name) ::Hazel::InstrumentationTimer timer##__LINE__(name);
-	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(HZ_FUNC_SIG)
+	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(::Hazel::clean_expression(HZ_FUNC_SIG).data)
 #else
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)
 	#define HZ_PROFILE_END_SESSION()

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -20,11 +20,12 @@ namespace Hazel {
 		template <size_t N>
 		constexpr auto RemoveCdecl(const char(&expr)[N])
 		{
-			ChangeResult<N> result = {};
+			ChangeResult<N> result;
 
 			size_t srcIndex = 0;
 			size_t dstIndex = 0;
-			while (srcIndex < N - 2) {
+			while (srcIndex < N - 2)
+			{
 				if (expr[srcIndex]     == '_' &&
 					expr[srcIndex + 1] == '_' &&
 					expr[srcIndex + 2] == 'c' &&
@@ -46,20 +47,14 @@ namespace Hazel {
 		template <size_t N>
 		constexpr auto ReplaceQuotes(const char(&expr)[N])
 		{
-			ChangeResult<N> result = {};
+			ChangeResult<N> result;
 
 			size_t srcIndex = 0;
 			size_t dstIndex = 0;
-			while (srcIndex < N - 2) {
-				if (expr[srcIndex] == '"')
-				{
-					result.Data[dstIndex++] = '\'';
-					srcIndex++;
-				}
-				else
-				{
-					result.Data[dstIndex++] = expr[srcIndex++];
-				}
+			while (srcIndex < N - 2)
+			{
+				result.Data[dstIndex++] = expr[srcIndex] == '"' ? '\'' : expr[srcIndex];
+				srcIndex++;
 			}
 			result.Data[dstIndex++] = expr[N - 2];
 			result.Data[dstIndex++] = expr[N - 1];
@@ -136,14 +131,11 @@ namespace Hazel {
 		{
 			std::stringstream json;
 
-			std::string name = result.Name;
-			std::replace(name.begin(), name.end(), '"', '\'');
-
 			json << std::setprecision(3) << std::fixed;
 			json << ",{";
 			json << "\"cat\":\"function\",";
 			json << "\"dur\":" << (result.ElapsedTime.count()) << ',';
-			json << "\"name\":\"" << name << "\",";
+			json << "\"name\":\"" << result.Name << "\",";
 			json << "\"ph\":\"X\",";
 			json << "\"pid\":0,";
 			json << "\"tid\":" << result.ThreadID << ",";

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -218,8 +218,8 @@ namespace Hazel {
 
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
 	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
-	#define HZ_PROFILE_SCOPE(name) constexpr auto fixedname = ::Hazel::InstrumentorUtils::CleanupOutputString(name, "__cdecl ");\
-									::Hazel::InstrumentationTimer timer##__LINE__(fixedname.Data);
+	#define HZ_PROFILE_SCOPE(name) constexpr auto fixedName = ::Hazel::InstrumentorUtils::CleanupOutputString(name, "__cdecl ");\
+									::Hazel::InstrumentationTimer timer##__LINE__(fixedName.Data);
 	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(HZ_FUNC_SIG)
 #else
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -10,13 +10,13 @@
 namespace Hazel {
 
 	template <size_t N>
-	struct fixed_string {
+	struct Fixed_String {
 		char data[N];
 	};
 
 	template <size_t N>
-	constexpr auto clean_expression(const char(&expr)[N]) {
-		fixed_string<N> result = {};
+	constexpr auto Clean_Expression(const char(&expr)[N]) {
+		Fixed_String<N> result = {};
 
 		int src_idx = 0;
 		int dst_idx = 0;
@@ -213,7 +213,7 @@ namespace Hazel {
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
 	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
 	#define HZ_PROFILE_SCOPE(name) ::Hazel::InstrumentationTimer timer##__LINE__(name);
-	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(::Hazel::clean_expression(HZ_FUNC_SIG).data)
+	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(::Hazel::Clean_Expression(HZ_FUNC_SIG).data)
 #else
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)
 	#define HZ_PROFILE_END_SESSION()

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -210,7 +210,7 @@ namespace Hazel {
 	#elif defined(__DMC__) && (__DMC__ >= 0x810)
 		#define HZ_FUNC_SIG __PRETTY_FUNCTION__
 	#elif (defined(__FUNCSIG__) || (_MSC_VER))
-		#define HZ_FUNC_SIG __FUNCSIG__
+		#define HZ_FUNC_SIG ::Hazel::CleanExpression(__FUNCSIG__).Data
 	#elif (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 600)) || (defined(__IBMCPP__) && (__IBMCPP__ >= 500))
 		#define HZ_FUNC_SIG __FUNCTION__
 	#elif defined(__BORLANDC__) && (__BORLANDC__ >= 0x550)
@@ -226,7 +226,7 @@ namespace Hazel {
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
 	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
 	#define HZ_PROFILE_SCOPE(name) ::Hazel::InstrumentationTimer timer##__LINE__(name);
-	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(::Hazel::CleanExpression(HZ_FUNC_SIG).Data)
+	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(HZ_FUNC_SIG)
 #else
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)
 	#define HZ_PROFILE_END_SESSION()

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -178,7 +178,7 @@ namespace Hazel {
 
 			size_t srcIndex = 0;
 			size_t dstIndex = 0;
-			while (srcIndex < N - 2)
+			while (srcIndex < N)
 			{
 				size_t matchIndex = 0;
 				while (matchIndex < K - 1 && srcIndex + matchIndex < N - 1 && expr[srcIndex + matchIndex] == remove[matchIndex])
@@ -187,8 +187,6 @@ namespace Hazel {
 					srcIndex += matchIndex;
 				result.Data[dstIndex++] = expr[srcIndex++];
 			}
-			result.Data[dstIndex++] = expr[N - 2];
-			result.Data[dstIndex++] = expr[N - 1];
 			return result;
 		}
 

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -66,7 +66,8 @@ namespace Hazel {
 	public:
 		Instrumentor()
 			: m_CurrentSession(nullptr)
-		{}
+		{
+		}
 
 		void BeginSession(const std::string& name, const std::string& filepath = "results.json")
 		{

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -12,7 +12,6 @@ namespace Hazel {
 	template <size_t N>
 	struct fixed_string {
 		char data[N];
-//		size_t size;
 	};
 
 	template <size_t N>
@@ -37,7 +36,6 @@ namespace Hazel {
 		}
 		result.data[dst_idx++] = expr[N - 2];
 		result.data[dst_idx++] = expr[N - 1];
-//		result.size = dst_idx;
 		return result;
 	}
 

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -197,13 +197,11 @@ namespace Hazel {
 
 			size_t srcIndex = 0;
 			size_t dstIndex = 0;
-			while (srcIndex < N - 2)
+			while (srcIndex < N)
 			{
 				result.Data[dstIndex++] = expr[srcIndex] == '"' ? '\'' : expr[srcIndex];
 				srcIndex++;
 			}
-			result.Data[dstIndex++] = expr[N - 2];
-			result.Data[dstIndex++] = expr[N - 1];
 			return result;
 		}
 	}

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -9,59 +9,6 @@
 
 namespace Hazel {
 
-	namespace InstrumentorUtils {
-
-		template <size_t N>
-		struct ChangeResult
-		{
-			char Data[N];
-		};
-
-		template <size_t N>
-		constexpr auto RemoveCdecl(const char(&expr)[N])
-		{
-			ChangeResult<N> result;
-
-			size_t srcIndex = 0;
-			size_t dstIndex = 0;
-			while (srcIndex < N - 2)
-			{
-				if (expr[srcIndex]     == '_' &&
-					expr[srcIndex + 1] == '_' &&
-					expr[srcIndex + 2] == 'c' &&
-					expr[srcIndex + 3] == 'd' &&
-					expr[srcIndex + 4] == 'e' &&
-					expr[srcIndex + 5] == 'c' &&
-					expr[srcIndex + 6] == 'l' &&
-					expr[srcIndex + 7] == ' ')
-				{
-					srcIndex += 8;
-				}
-				result.Data[dstIndex++] = expr[srcIndex++];
-			}
-			result.Data[dstIndex++] = expr[N - 2];
-			result.Data[dstIndex++] = expr[N - 1];
-			return result;
-		}
-
-		template <size_t N>
-		constexpr auto ReplaceQuotes(const char(&expr)[N])
-		{
-			ChangeResult<N> result;
-
-			size_t srcIndex = 0;
-			size_t dstIndex = 0;
-			while (srcIndex < N - 2)
-			{
-				result.Data[dstIndex++] = expr[srcIndex] == '"' ? '\'' : expr[srcIndex];
-				srcIndex++;
-			}
-			result.Data[dstIndex++] = expr[N - 2];
-			result.Data[dstIndex++] = expr[N - 1];
-			return result;
-		}
-	}
-
 	using FloatingPointMicroseconds = std::chrono::duration<double, std::micro>;
 
 	struct ProfileResult
@@ -217,6 +164,59 @@ namespace Hazel {
 		std::chrono::time_point<std::chrono::steady_clock> m_StartTimepoint;
 		bool m_Stopped;
 	};
+
+	namespace InstrumentorUtils {
+
+		template <size_t N>
+		struct ChangeResult
+		{
+			char Data[N];
+		};
+
+		template <size_t N>
+		constexpr auto RemoveCdecl(const char(&expr)[N])
+		{
+			ChangeResult<N> result;
+
+			size_t srcIndex = 0;
+			size_t dstIndex = 0;
+			while (srcIndex < N - 2)
+			{
+				if (expr[srcIndex] == '_' &&
+					expr[srcIndex + 1] == '_' &&
+					expr[srcIndex + 2] == 'c' &&
+					expr[srcIndex + 3] == 'd' &&
+					expr[srcIndex + 4] == 'e' &&
+					expr[srcIndex + 5] == 'c' &&
+					expr[srcIndex + 6] == 'l' &&
+					expr[srcIndex + 7] == ' ')
+				{
+					srcIndex += 8;
+				}
+				result.Data[dstIndex++] = expr[srcIndex++];
+			}
+			result.Data[dstIndex++] = expr[N - 2];
+			result.Data[dstIndex++] = expr[N - 1];
+			return result;
+		}
+
+		template <size_t N>
+		constexpr auto ReplaceQuotes(const char(&expr)[N])
+		{
+			ChangeResult<N> result;
+
+			size_t srcIndex = 0;
+			size_t dstIndex = 0;
+			while (srcIndex < N - 2)
+			{
+				result.Data[dstIndex++] = expr[srcIndex] == '"' ? '\'' : expr[srcIndex];
+				srcIndex++;
+			}
+			result.Data[dstIndex++] = expr[N - 2];
+			result.Data[dstIndex++] = expr[N - 1];
+			return result;
+		}
+	}
 }
 
 #define HZ_PROFILE 0

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -185,20 +185,6 @@ namespace Hazel {
 					matchIndex++;
 				if (matchIndex == K - 1)
 					srcIndex += matchIndex;
-				result.Data[dstIndex++] = expr[srcIndex++];
-			}
-			return result;
-		}
-
-		template <size_t N>
-		constexpr auto ReplaceQuotes(const char(&expr)[N])
-		{
-			ChangeResult<N> result;
-
-			size_t srcIndex = 0;
-			size_t dstIndex = 0;
-			while (srcIndex < N)
-			{
 				result.Data[dstIndex++] = expr[srcIndex] == '"' ? '\'' : expr[srcIndex];
 				srcIndex++;
 			}
@@ -217,7 +203,7 @@ namespace Hazel {
 	#elif defined(__DMC__) && (__DMC__ >= 0x810)
 		#define HZ_FUNC_SIG __PRETTY_FUNCTION__
 	#elif (defined(__FUNCSIG__) || (_MSC_VER))
-		#define HZ_FUNC_SIG ::Hazel::InstrumentorUtils::CleanupOutputString(__FUNCSIG__, "__cdecl ").Data
+		#define HZ_FUNC_SIG __FUNCSIG__
 	#elif (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 600)) || (defined(__IBMCPP__) && (__IBMCPP__ >= 500))
 		#define HZ_FUNC_SIG __FUNCTION__
 	#elif defined(__BORLANDC__) && (__BORLANDC__ >= 0x550)
@@ -232,7 +218,7 @@ namespace Hazel {
 
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
 	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
-	#define HZ_PROFILE_SCOPE(name) ::Hazel::InstrumentationTimer timer##__LINE__(::Hazel::InstrumentorUtils::ReplaceQuotes(name).Data);
+	#define HZ_PROFILE_SCOPE(name) ::Hazel::InstrumentationTimer timer##__LINE__(::Hazel::InstrumentorUtils::CleanupOutputString(name, "__cdecl ").Data);
 	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(HZ_FUNC_SIG)
 #else
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -218,7 +218,8 @@ namespace Hazel {
 
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
 	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
-	#define HZ_PROFILE_SCOPE(name) ::Hazel::InstrumentationTimer timer##__LINE__(::Hazel::InstrumentorUtils::CleanupOutputString(name, "__cdecl ").Data);
+	#define HZ_PROFILE_SCOPE(name) constexpr auto fixedname = ::Hazel::InstrumentorUtils::CleanupOutputString(name, "__cdecl ");\
+									::Hazel::InstrumentationTimer timer##__LINE__(fixedname.Data);
 	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(HZ_FUNC_SIG)
 #else
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
It is not really an issue - just a "cosmetic fix". Inside our Instrumentor output we have this annyoing "__cdecl" output on MSVC compiler. This pull request removes this at compile time.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Closes #191 
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
I added a new function (Clean_Expression) and a struct (Fixed_String) to the Instrumentor.h file and changed the HZ_PROFILE_FUNCTION macro to use it.
The Clean_Expression function goes through the output and removes the "__cdecl" from it.

#### Additional context
So nice as this works we still have the problem, that MSVC replaces things like "std::string" with "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >" or "glm::vec3" with something like "glm::vec<3,float,0>" .. and that doesn't really look nice.

EDIT by @LovelySanta: linked the related issue