### PR TITLE
Branching instead of indexing the texture sampler

### DIFF
--- a/Sandbox/assets/shaders/Texture.glsl
+++ b/Sandbox/assets/shaders/Texture.glsl
@@ -39,5 +39,40 @@ uniform sampler2D u_Textures[32];
 
 void main()
 {
-	color = texture(u_Textures[int(v_TexIndex)], v_TexCoord * v_TilingFactor) * v_Color;
+	vec4 texColor = v_Color;
+	switch(int(v_TexIndex))
+	{
+		case 0: texColor *= texture(u_Textures[0], v_TexCoord * v_TilingFactor); break;
+		case 1: texColor *= texture(u_Textures[1], v_TexCoord * v_TilingFactor); break;
+		case 2: texColor *= texture(u_Textures[2], v_TexCoord * v_TilingFactor); break;
+		case 3: texColor *= texture(u_Textures[3], v_TexCoord * v_TilingFactor); break;
+		case 5: texColor *= texture(u_Textures[5], v_TexCoord * v_TilingFactor); break;
+		case 6: texColor *= texture(u_Textures[6], v_TexCoord * v_TilingFactor); break;
+		case 7: texColor *= texture(u_Textures[7], v_TexCoord * v_TilingFactor); break;
+		case 8: texColor *= texture(u_Textures[8], v_TexCoord * v_TilingFactor); break;
+		case 9: texColor *= texture(u_Textures[9], v_TexCoord * v_TilingFactor); break;
+		case 10: texColor *= texture(u_Textures[10], v_TexCoord * v_TilingFactor); break;
+		case 11: texColor *= texture(u_Textures[11], v_TexCoord * v_TilingFactor); break;
+		case 12: texColor *= texture(u_Textures[12], v_TexCoord * v_TilingFactor); break;
+		case 13: texColor *= texture(u_Textures[13], v_TexCoord * v_TilingFactor); break;
+		case 14: texColor *= texture(u_Textures[14], v_TexCoord * v_TilingFactor); break;
+		case 15: texColor *= texture(u_Textures[15], v_TexCoord * v_TilingFactor); break;
+		case 16: texColor *= texture(u_Textures[16], v_TexCoord * v_TilingFactor); break;
+		case 17: texColor *= texture(u_Textures[17], v_TexCoord * v_TilingFactor); break;
+		case 18: texColor *= texture(u_Textures[18], v_TexCoord * v_TilingFactor); break;
+		case 19: texColor *= texture(u_Textures[19], v_TexCoord * v_TilingFactor); break;
+		case 20: texColor *= texture(u_Textures[20], v_TexCoord * v_TilingFactor); break;
+		case 21: texColor *= texture(u_Textures[21], v_TexCoord * v_TilingFactor); break;
+		case 22: texColor *= texture(u_Textures[22], v_TexCoord * v_TilingFactor); break;
+		case 23: texColor *= texture(u_Textures[23], v_TexCoord * v_TilingFactor); break;
+		case 24: texColor *= texture(u_Textures[24], v_TexCoord * v_TilingFactor); break;
+		case 25: texColor *= texture(u_Textures[25], v_TexCoord * v_TilingFactor); break;
+		case 26: texColor *= texture(u_Textures[26], v_TexCoord * v_TilingFactor); break;
+		case 27: texColor *= texture(u_Textures[27], v_TexCoord * v_TilingFactor); break;
+		case 28: texColor *= texture(u_Textures[28], v_TexCoord * v_TilingFactor); break;
+		case 29: texColor *= texture(u_Textures[29], v_TexCoord * v_TilingFactor); break;
+		case 30: texColor *= texture(u_Textures[30], v_TexCoord * v_TilingFactor); break;
+		case 31: texColor *= texture(u_Textures[31], v_TexCoord * v_TilingFactor); break;
+	}
+	color = texColor;
 }


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
As stated in #238, the texture sampler can only be indexed with a dynamically uniform integral expression. Not doing so results in quads rendering black instead of rendering textures on certain systems.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Closes #238
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Branch the sampler instead of indexing it. Since currently Hazel supports 32 texture slots, I've branched up to 32 textures.

#### Additional context
In discord this is confirmed to resolve the black quad drawings. Since it wasn't an issue for me, I can only test that it still works. However, @9Y0 confirmed that this resolves the black quad drawing.
