### PR TITLE
Added error logs to Instrumentor in case no session is open.

### DIFF
--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -95,6 +95,10 @@ namespace Hazel {
 				m_OutputStream << json.str();
 				m_OutputStream.flush();
 			}
+			else if (Log::GetCoreLogger()) // Edge case: WriteProfile() might be before Log::Init()
+			{
+				HZ_CORE_ERROR("Could not write ProfileResult, Instrumentor is not in session.");
+			}
 		}
 
 		static Instrumentor& Get()
@@ -127,6 +131,10 @@ namespace Hazel {
 				m_OutputStream.close();
 				delete m_CurrentSession;
 				m_CurrentSession = nullptr;
+			}
+			else if (Log::GetCoreLogger()) // Edge case: InternalEndSession() might be before Log::Init()
+			{
+				HZ_CORE_ERROR("Could not end session, Instrumentor is not in session.");
 			}
 		}
 


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The instrumentor doesn't print error messages when writing profile results or ending a session if there is no session open. This might be unclear to the user.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Add logging of these errors in WriteProfile and InternalEndSession functions.
