### PR TITLE
Fixed copy and paste mistake on EntryPoint.h

### DIFF
--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -17,7 +17,7 @@ int main(int argc, char** argv)
 	app->Run();
 	HZ_PROFILE_END_SESSION();
 
-	HZ_PROFILE_BEGIN_SESSION("Startup", "HazelProfile-Shutdown.json");
+	HZ_PROFILE_BEGIN_SESSION("Shutdown", "HazelProfile-Shutdown.json");
 	delete app;
 	HZ_PROFILE_END_SESSION();
 }


### PR DESCRIPTION
The profiler should treat deleting the app as a different session.