### PR TITLE
Change submodule references to relative paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,16 @@
 [submodule "Hazel/vendor/spdlog"]
 	path = Hazel/vendor/spdlog
-	url = https://github.com/gabime/spdlog
+	url = ../../gabime/spdlog.git
 	branch = v1.x
 [submodule "Hazel/vendor/GLFW"]
 	path = Hazel/vendor/GLFW
-	url = https://github.com/TheCherno/glfw
+	url = ../../TheCherno/glfw.git
 	branch = master
 [submodule "Hazel/vendor/imgui"]
 	path = Hazel/vendor/imgui
-	url = https://github.com/TheCherno/imgui
+	url = ../../TheCherno/imgui.git
 	branch = docking
 [submodule "Hazel/vendor/glm"]
 	path = Hazel/vendor/glm
-	url = https://github.com/g-truc/glm
+	url = ../../g-truc/glm.git
 	branch = master


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
When cloning Hazel repository by using SSH GitHub path, submodules are cloned using HTTPS instead of following user-preferred protocol and potentially causing issues if there is HTTPS proxy configured.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Paths to submodules in `.gitmodules` are changed to relative - this causes them to use same protocol for communication with remote as Hazel. Suffix `.git` added to allow paths work with both HTTPS and SSH address.

#### Additional context
For repositories already cloned, including forks, change in `.gitmodules` will have no effect unless `git submodule sync` command is used.

User account part of path in GLFW and imgui submodules (`/TheCherno/`) is specified explicitly to keep submodules working when main repository is cloned from fork.