### PR TITLE
Add missing branch in Texture.glsl

### DIFF
--- a/Sandbox/assets/shaders/Texture.glsl
+++ b/Sandbox/assets/shaders/Texture.glsl
@@ -46,6 +46,7 @@ void main()
 		case 1: texColor *= texture(u_Textures[1], v_TexCoord * v_TilingFactor); break;
 		case 2: texColor *= texture(u_Textures[2], v_TexCoord * v_TilingFactor); break;
 		case 3: texColor *= texture(u_Textures[3], v_TexCoord * v_TilingFactor); break;
+		case 4: texColor *= texture(u_Textures[4], v_TexCoord * v_TilingFactor); break;
 		case 5: texColor *= texture(u_Textures[5], v_TexCoord * v_TilingFactor); break;
 		case 6: texColor *= texture(u_Textures[6], v_TexCoord * v_TilingFactor); break;
 		case 7: texColor *= texture(u_Textures[7], v_TexCoord * v_TilingFactor); break;


### PR DESCRIPTION
Fixes a branch missing in the texture shader. 