### PR TITLE
Handling non-QWERTY keyboards with GLFW

### DIFF
--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -90,6 +90,12 @@ namespace Hazel {
 		{
 			WindowData& data = *(WindowData*)glfwGetWindowUserPointer(window);
 
+			//Adapting to non-QWERTY keyboards (like AZERTY or QWERTZ)
+			if (key >= GLFW_KEY_A && key <= GLFW_KEY_Z) {
+				const std::string keyName = glfwGetKeyName(key, scancode);
+				key = GLFW_KEY_A + (std::toupper(keyName[0]) - 'A'); //this way, we ensure that no matter the code that GLFW uses, the keycode will be correct
+			}
+
 			switch (action)
 			{
 				case GLFW_PRESS:


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
As described in the issue #261 , currently Hazel doesn't handle non-QWERTY keyboards. This can be a real issue for non-QWERTY users (like AZERTY users).

#### PR impact 
List of related issues/PRs this will solve:
 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       |  #261 
Other PRs this solves    | None 

#### Proposed fix
Now in the glfwSetKeyCallBack() function, we check if the current key is a letter. If so, we adapt to the keyboard layout the keycode that the key event will have.

