### PR TITLE
Deleting textures on OpenGLFramebuffer Destructor

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLFramebuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLFramebuffer.cpp
@@ -14,6 +14,8 @@ namespace Hazel {
 	OpenGLFramebuffer::~OpenGLFramebuffer()
 	{
 		glDeleteFramebuffers(1, &m_RendererID);
+		glDeleteTextures(1, &m_ColorAttachment);
+		glDeleteTextures(1, &m_DepthAttachment);
 	}
 
 	void OpenGLFramebuffer::Invalidate()


### PR DESCRIPTION
#### Describe the issue
The textures that are being created by an OpenGLFramebuffer object are never being destroyed. 

#### PR impact 
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix 
The issue was fixed by adding to the OpenGLFramebuffer destructor this two lines:
```
glDeleteTextures(1, &m_ColorAttachment);
glDeleteTextures(1, &m_DepthAttachment);
```