### PR TITLE
Update EditorLayer.h

### DIFF
--- a/Hazelnut/src/EditorLayer.h
+++ b/Hazelnut/src/EditorLayer.h
@@ -17,7 +17,7 @@ namespace Hazel {
 		virtual void OnImGuiRender() override;
 		void OnEvent(Event& e) override;
 	private:
-		Hazel::OrthographicCameraController m_CameraController;
+		OrthographicCameraController m_CameraController;
 
 		// Temp
 		Ref<VertexArray> m_SquareVA;


### PR DESCRIPTION
missed a `Hazel::` when refactored the code when moving from Sandbox to Hazelnut

#### Describe the issue
In the video when @TheCherno copied all of the code from sandbox to hazelnut he put all of the code inside of namespace Hazel and said that he would delete all of the Hazel:: prefixes.
he missed this one.

#### Proposed fix
just deleted the `Hazel::`