### PR TITLE
adjust repeated key presses to bool instead of int

### DIFF
--- a/Hazel/src/Hazel/Events/KeyEvent.h
+++ b/Hazel/src/Hazel/Events/KeyEvent.h
@@ -21,8 +21,8 @@ namespace Hazel {
 	class KeyPressedEvent : public KeyEvent
 	{
 	public:
-		KeyPressedEvent(KeyCode keycode, int repeatCount)
-			: KeyEvent(keycode), m_Repeated(repeatCount) {}
+		KeyPressedEvent(KeyCode keycode, bool repeated)
+			: KeyEvent(keycode), m_Repeated(repeated) {}
 
 		bool GetRepeatCount() const { return m_Repeated; }
 

--- a/Hazel/src/Hazel/Events/KeyEvent.h
+++ b/Hazel/src/Hazel/Events/KeyEvent.h
@@ -22,20 +22,20 @@ namespace Hazel {
 	{
 	public:
 		KeyPressedEvent(KeyCode keycode, int repeatCount)
-			: KeyEvent(keycode), m_RepeatCount(repeatCount) {}
+			: KeyEvent(keycode), m_Repeated(repeatCount) {}
 
-		int GetRepeatCount() const { return m_RepeatCount; }
+		bool GetRepeatCount() const { return m_Repeated; }
 
 		std::string ToString() const override
 		{
 			std::stringstream ss;
-			ss << "KeyPressedEvent: " << m_KeyCode << " (" << m_RepeatCount << " repeats)";
+			ss << "KeyPressedEvent: " << m_KeyCode << " (" << "Repeated: " << m_Repeated << ")";
 			return ss.str();
 		}
 
 		EVENT_CLASS_TYPE(KeyPressed)
 	private:
-		int m_RepeatCount;
+		bool m_Repeated;
 	};
 
 	class KeyReleasedEvent : public KeyEvent

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -94,7 +94,7 @@ namespace Hazel {
 			{
 				case GLFW_PRESS:
 				{
-					KeyPressedEvent event(static_cast<KeyCode>(key), 0);
+					KeyPressedEvent event(static_cast<KeyCode>(key), false);
 					data.EventCallback(event);
 					break;
 				}
@@ -106,7 +106,7 @@ namespace Hazel {
 				}
 				case GLFW_REPEAT:
 				{
-					KeyPressedEvent event(static_cast<KeyCode>(key), 1);
+					KeyPressedEvent event(static_cast<KeyCode>(key), true);
 					data.EventCallback(event);
 					break;
 				}


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Repeat key presses don't increase the repeat count and hasn't been implemented since Cherno's key events video.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Change repeat count from int to bool
