### PR TITLE
imgui_blocking_alternative

### DIFF
--- a/Hazel/src/Hazel/Core/Application.h
+++ b/Hazel/src/Hazel/Core/Application.h
@@ -30,8 +30,6 @@ namespace Hazel {
 
 		void Close();
 
-		ImGuiLayer* GetImGuiLayer() { return m_ImGuiLayer; }
-
 		static Application& Get() { return *s_Instance; }
 	private:
 		void Run();

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
@@ -64,12 +64,9 @@ namespace Hazel {
 
 	void ImGuiLayer::OnEvent(Event& e)
 	{
-		if (m_BlockEvents)
-		{
-			ImGuiIO& io = ImGui::GetIO();
-			e.Handled |= e.IsInCategory(EventCategoryMouse) & io.WantCaptureMouse;
-			e.Handled |= e.IsInCategory(EventCategoryKeyboard) & io.WantCaptureKeyboard;
-		}
+		ImGuiIO& io = ImGui::GetIO();
+		e.Handled |= e.IsInCategory(EventCategoryMouse) & io.WantCaptureMouse;
+		e.Handled |= e.IsInCategory(EventCategoryKeyboard) & io.WantCaptureKeyboard;
 	}
 	
 	void ImGuiLayer::Begin()

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.h
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.h
@@ -20,10 +20,7 @@ namespace Hazel {
 
 		void Begin();
 		void End();
-
-		void BlockEvents(bool block) { m_BlockEvents = block; }
 	private:
-		bool m_BlockEvents = true;
 		float m_Time = 0.0f;
 	};
 

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -154,7 +154,8 @@ namespace Hazel {
 
 		m_ViewportFocused = ImGui::IsWindowFocused();
 		m_ViewportHovered = ImGui::IsWindowHovered();
-		Application::Get().GetImGuiLayer()->BlockEvents(!m_ViewportFocused || !m_ViewportHovered);
+		io.WantCaptureMouse &= !m_ViewportFocused || !m_ViewportHovered;
+		io.WantCaptureKeyboard &= !m_ViewportFocused || !m_ViewportHovered;
 
 		ImVec2 viewportPanelSize = ImGui::GetContentRegionAvail();
 		if (m_ViewportSize != *((glm::vec2*)&viewportPanelSize))


### PR DESCRIPTION
#### PR impact
This PR doesn't really have an impact, just an alternative solution.  

List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None 
Other PRs this solves    | None

#### Proposed fix 
This part will maintain the same behavior:
```
io.WantCaptureMouse &= !m_ViewportFocused || !m_ViewportHovered;
io.WantCaptureKeyboard &= !m_ViewportFocused || !m_ViewportHovered;
```
 which can be replaced by:
```
io.WantCaptureMouse = !m_ViewportHovered;
io.WantCaptureKeyboard = !m_ViewportFocused;
```
changing the behavior so that the user can scroll inside the viewport even if it isn't focused.  Which is similar to Chrome and Visual Studio.