### PR TITLE
replaced std::bind with lambda in HZ_BIND_EVENT_FN macro

### DIFF
--- a/Hazel/src/Hazel/Core/Base.h
+++ b/Hazel/src/Hazel/Core/Base.h
@@ -67,7 +67,7 @@
 
 #define BIT(x) (1 << x)
 
-#define HZ_BIND_EVENT_FN(fn) [this](auto&&... args) { return this->fn(args...); }
+#define HZ_BIND_EVENT_FN(fn) [this](auto&&... args) -> decltype(auto) { return this->fn(std::forward<decltype(args)>(args)...); }
 
 namespace Hazel {
 

--- a/Hazel/src/Hazel/Core/Base.h
+++ b/Hazel/src/Hazel/Core/Base.h
@@ -67,7 +67,7 @@
 
 #define BIT(x) (1 << x)
 
-#define HZ_BIND_EVENT_FN(fn) std::bind(&fn, this, std::placeholders::_1)
+#define HZ_BIND_EVENT_FN(fn) [this](auto&&... args) { return this->fn(args...); }
 
 namespace Hazel {
 


### PR DESCRIPTION
using std::bind in modern C++ is a bad practice, as lambdas can do the same and much more

#### PR impact

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
```cpp
#define HZ_BIND_EVENT_FN(fn) std::bind(&fn, this, std::placeholders::_1)
```
is replaced with
```cpp
#define HZ_BIND_EVENT_FN(fn) [this](auto&&... args) -> decltype(auto) \ 
{ return this->fn(std::forward<decltype(args)>(args)...); }
```
~Behaviour of the code and api remain the same. args are not forwarded, but it will be weird to accept argument by value in event funtions and do not expect copying, so I do not see a problem here~
Behaviour of the code and api remain the same. Return type is correctly deduced and no additional copying of arguments performed

### Additional context
variadic args in lambdas were added in C++17. I suppose Hazel supports latest standard, so I can use this feature in engine code.