### PR TITLE
Fixed __LINE__ not expanding in instrumentor

### DIFF
--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -218,8 +218,10 @@ namespace Hazel {
 
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath) ::Hazel::Instrumentor::Get().BeginSession(name, filepath)
 	#define HZ_PROFILE_END_SESSION() ::Hazel::Instrumentor::Get().EndSession()
-	#define HZ_PROFILE_SCOPE(name) constexpr auto fixedName = ::Hazel::InstrumentorUtils::CleanupOutputString(name, "__cdecl ");\
-									::Hazel::InstrumentationTimer timer##__LINE__(fixedName.Data)
+	#define HZ_PROFILE_SCOPE_LINE2(name, line) constexpr auto fixedName##line = ::Hazel::InstrumentorUtils::CleanupOutputString(name, "__cdecl ");\
+											   ::Hazel::InstrumentationTimer timer##line(fixedName##line.Data)
+	#define HZ_PROFILE_SCOPE_LINE(name, line) HZ_PROFILE_SCOPE_LINE2(name, line)
+	#define HZ_PROFILE_SCOPE(name) HZ_PROFILE_SCOPE_LINE(name, __LINE__)
 	#define HZ_PROFILE_FUNCTION() HZ_PROFILE_SCOPE(HZ_FUNC_SIG)
 #else
 	#define HZ_PROFILE_BEGIN_SESSION(name, filepath)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Currently, Instrumentor's macros create fields the names of which expand to timer__LINE__, which means that you can't define multiple within the same scope.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Instrumentor variable doesn't expand \_\_LINE\_\_       | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
As described in [this stackoverflow answer](https://stackoverflow.com/a/1597129), macros only expand recursively if neither the # or ## operator are applied to it, so I have added some indirection that forces the \_\_LINE\_\_ macro to expand.

#### Additional context
I have tested the solution with both Clang and MSVC, and the macro expands correctly in both, I haven't tested with GCC, but as per the aforementioned SO answer, this fix should work with it as well.

I have also tested with only one level of indirection, but it only seems to work with two, likely because it passes the macro itself as a parameter rather than its value.