### PR TITLE
Fixed potential memory leak and malformed JSON in Instrumentor. 

### DIFF
--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -107,7 +107,7 @@ namespace Hazel {
 
 		~Instrumentor()
 		{
-			InternalEndSession();
+			EndSession();
 		}		
 
 		void WriteHeader()

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -27,15 +27,10 @@ namespace Hazel {
 
 	class Instrumentor
 	{
-	private:
-		std::mutex m_Mutex;
-		InstrumentationSession* m_CurrentSession;
-		std::ofstream m_OutputStream;
+	
 	public:
-		Instrumentor()
-			: m_CurrentSession(nullptr)
-		{
-		}
+		Instrumentor(const Instrumentor&) = delete;
+		Instrumentor(Instrumentor&&) = delete;
 
 		void BeginSession(const std::string& name, const std::string& filepath = "results.json")
 		{
@@ -105,6 +100,16 @@ namespace Hazel {
 
 	private:
 
+		Instrumentor()
+			: m_CurrentSession(nullptr)
+		{
+		}
+
+		~Instrumentor()
+		{
+			InternalEndSession();
+		}		
+
 		void WriteHeader()
 		{
 			m_OutputStream << "{\"otherData\": {},\"traceEvents\":[{}";
@@ -129,6 +134,10 @@ namespace Hazel {
 				m_CurrentSession = nullptr;
 			}
 		}
+
+		std::mutex m_Mutex;
+		InstrumentationSession* m_CurrentSession;
+		std::ofstream m_OutputStream;
 
 	};
 

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -27,7 +27,6 @@ namespace Hazel {
 
 	class Instrumentor
 	{
-	
 	public:
 		Instrumentor(const Instrumentor&) = delete;
 		Instrumentor(Instrumentor&&) = delete;
@@ -97,9 +96,7 @@ namespace Hazel {
 			static Instrumentor instance;
 			return instance;
 		}
-
 	private:
-
 		Instrumentor()
 			: m_CurrentSession(nullptr)
 		{
@@ -134,11 +131,10 @@ namespace Hazel {
 				m_CurrentSession = nullptr;
 			}
 		}
-
+	private:
 		std::mutex m_Mutex;
 		InstrumentationSession* m_CurrentSession;
 		std::ofstream m_OutputStream;
-
 	};
 
 	class InstrumentationTimer


### PR DESCRIPTION

#### Describe the issue (if no issue has been made)
When using the Instrumentor for profiling, if a session is begun using `HZ_PROFILE_BEGIN_SESSION(name, filepath)` but `HZ_PROFILE_END_SESSION()` is not called before the program ends then the heap allocated `InstrumentationSession` is not deleted and the footer is not added to the file which creates malformed JSON. 

Also, the constructor for `Instrumentor` is public but `Instrumentor` is being used as a singleton, therefore more than one instance can be made.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Potential memory leak in `Instrumentor`, malformed JSON in profiling data, multiple instances of singleton       | None


#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_

- The memory leak and malformed JSON were fixed by writing a destructor for `Instrumentor` that called `InternalEndSession`. 
- The multiple instances of the singleton were prevented by making the constructor and destructor for `Instrumentor` private and explicitly deleting the copy and move constructors. 

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.
Tested on Windows only. I also made a couple of larger changes which can be seen in the gist here https://gist.github.com/studiob56/1a3b917b5b517045e8b5112d96fc20e3
Wherein I moved the writing to file etc to be managed by the `InstrumentationSession` itself rather than the `Instrumentor`, and also changed the instance of the session to be in an `std::optional` rather than as a heap allocation.
