### PR TITLE
Fix conversion error

### DIFF
--- a/Hazel/src/Hazel/Scene/Entity.h
+++ b/Hazel/src/Hazel/Scene/Entity.h
@@ -40,7 +40,7 @@ namespace Hazel {
 			m_Scene->m_Registry.remove<T>(m_EntityHandle);
 		}
 
-		operator bool() const { return m_EntityHandle != 0; }
+		operator bool() const { return static_cast<int>(m_EntityHandle) != 0; }
 	private:
 		entt::entity m_EntityHandle{ 0 };
 		Scene* m_Scene = nullptr;

--- a/Hazel/src/Hazel/Scene/Entity.h
+++ b/Hazel/src/Hazel/Scene/Entity.h
@@ -40,9 +40,9 @@ namespace Hazel {
 			m_Scene->m_Registry.remove<T>(m_EntityHandle);
 		}
 
-		operator bool() const { return static_cast<int>(m_EntityHandle) != 0; }
+		operator bool() const { return m_EntityHandle != entt::null; }
 	private:
-		entt::entity m_EntityHandle{ 0 };
+		entt::entity m_EntityHandle{ entt::null };
 		Scene* m_Scene = nullptr;
 	};
 


### PR DESCRIPTION
 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Resolves #284 

#### Proposed fix
Use `entt::null` to fix the conversion type error in `Entity.h`.

EDIT by @LovelySanta: Added [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords).