### PR TITLE
Entt::View camera iteration

### DIFF
--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -79,6 +79,7 @@ namespace Hazel {
 						Renderer2D::DrawQuad(transformComp.Transform, spriteComp.Color);
 					});
 					Renderer2D::EndScene();
+					return;
 				}
 			});
 	}

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -63,35 +63,28 @@ namespace Hazel {
 	void Scene::OnUpdate(Timestep ts)
 	{
 		// Render 2D
-		Camera* mainCamera = nullptr;
-		glm::mat4* cameraTransform = nullptr;
-		{
-			m_Registry.view<TransformComponent, CameraComponent>().each(
-				// cameraEntity can be avoided to be captured
-				[&mainCamera, &cameraTransform](const auto& cameraEntity, auto& transformComp, auto& cameraComp)
-				{
-						if (cameraComp.Primary) {
-							mainCamera = &cameraComp.Camera;
-							cameraTransform = &transformComp.Transform;
-						}
-				});
-		}
 
-		if (mainCamera)
-		{
-			Renderer2D::BeginScene(mainCamera->GetProjection(), *cameraTransform);
-
-			auto group = m_Registry.group<TransformComponent>(entt::get<SpriteRendererComponent>);
-			for (auto entity : group)
+		m_Registry.view<TransformComponent, CameraComponent>().each(
+			// cameraEntity can be avoided to be captured
+			[&]( [[maybe_unused]] const auto cameraEntity, const auto& transformComp, const auto& cameraComp)
 			{
-				auto& [transform, sprite] = group.get<TransformComponent, SpriteRendererComponent>(entity);
+				const auto &camera = cameraComp.Camera;
+				const auto& transform = transformComp.Transform;
+				if (cameraComp.Primary) {
 
-				Renderer2D::DrawQuad(transform, sprite.Color);
-			}
+					Renderer2D::BeginScene(camera.GetProjection(), transform);
 
-			Renderer2D::EndScene();
-		}
+					auto group = m_Registry.group<TransformComponent>(entt::get<SpriteRendererComponent>);
+					for (auto entity : group)
+					{
+						auto& [transform, sprite] = group.get<TransformComponent, SpriteRendererComponent>(entity);
 
+						Renderer2D::DrawQuad(transform, sprite.Color);
+					}
+
+					Renderer2D::EndScene();
+				}
+			});
 	}
 
 }

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -74,14 +74,10 @@ namespace Hazel {
 
 					Renderer2D::BeginScene(camera.GetProjection(), transform);
 
-					auto group = m_Registry.group<TransformComponent>(entt::get<SpriteRendererComponent>);
-					for (auto entity : group)
-					{
-						auto& [transform, sprite] = group.get<TransformComponent, SpriteRendererComponent>(entity);
-
-						Renderer2D::DrawQuad(transform, sprite.Color);
-					}
-
+					m_Registry.group<TransformComponent>(entt::get<SpriteRendererComponent>).each(
+						[](const auto& transformComp, const auto& spriteComp) {
+						Renderer2D::DrawQuad(transformComp.Transform, spriteComp.Color);
+					});
 					Renderer2D::EndScene();
 				}
 			});

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -66,18 +66,15 @@ namespace Hazel {
 		Camera* mainCamera = nullptr;
 		glm::mat4* cameraTransform = nullptr;
 		{
-			auto group = m_Registry.view<TransformComponent, CameraComponent>();
-			for (auto entity : group)
-			{
-				auto& [transform, camera] = group.get<TransformComponent, CameraComponent>(entity);
-				
-				if (camera.Primary)
+			m_Registry.view<TransformComponent, CameraComponent>().each(
+				// cameraEntity can be avoided to be captured
+				[&mainCamera, &cameraTransform](const auto& cameraEntity, auto& transformComp, auto& cameraComp)
 				{
-					mainCamera = &camera.Camera;
-					cameraTransform = &transform.Transform;
-					break;
-				}
-			}
+						if (cameraComp.Primary) {
+							mainCamera = &cameraComp.Camera;
+							cameraTransform = &transformComp.Transform;
+						}
+				});
 		}
 
 		if (mainCamera)


### PR DESCRIPTION

This PR shows an alternative to use EnTT for fast iteration over entites/components.
By avoiding fetching components per each entity it's possible to have a better usage of L1/L2 caches, plus less code ;)


Thanks for your video series, very inspiring and intertainig 🙏 
