### PR TITLE
Improvements in Input system

### DIFF
--- a/Hazel/src/Hazel/Core/Input.h
+++ b/Hazel/src/Hazel/Core/Input.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <glm/glm.hpp>
+
 #include "Hazel/Core/Base.h"
 #include "Hazel/Core/KeyCodes.h"
 #include "Hazel/Core/MouseCodes.h"
@@ -9,10 +11,10 @@ namespace Hazel {
 	class Input
 	{
 	public:
-		static bool IsKeyPressed(KeyCode key);
+		static bool IsKeyPressed(uint16_t key);
 
-		static bool IsMouseButtonPressed(MouseCode button);
-		static std::pair<float, float> GetMousePosition();
+		static bool IsMouseButtonPressed(uint16_t button);
+		static glm::vec2 GetMousePosition();
 		static float GetMouseX();
 		static float GetMouseY();
 	};

--- a/Hazel/src/Hazel/Core/KeyCodes.h
+++ b/Hazel/src/Hazel/Core/KeyCodes.h
@@ -2,146 +2,145 @@
 
 namespace Hazel
 {
-	typedef enum class KeyCode : uint16_t
+	namespace KeyCode
 	{
-		// From glfw3.h
-		Space               = 32,
-		Apostrophe          = 39, /* ' */
-		Comma               = 44, /* , */
-		Minus               = 45, /* - */
-		Period              = 46, /* . */
-		Slash               = 47, /* / */
+		enum : uint16_t
+		{
+			// From glfw3.h
+			Space               = 32,
+			Apostrophe          = 39, /* ' */
+			Comma               = 44, /* , */
+			Minus               = 45, /* - */
+			Period              = 46, /* . */
+			Slash               = 47, /* / */
 
-		D0                  = 48, /* 0 */
-		D1                  = 49, /* 1 */
-		D2                  = 50, /* 2 */
-		D3                  = 51, /* 3 */
-		D4                  = 52, /* 4 */
-		D5                  = 53, /* 5 */
-		D6                  = 54, /* 6 */
-		D7                  = 55, /* 7 */
-		D8                  = 56, /* 8 */
-		D9                  = 57, /* 9 */
+			D0                  = 48, /* 0 */
+			D1                  = 49, /* 1 */
+			D2                  = 50, /* 2 */
+			D3                  = 51, /* 3 */
+			D4                  = 52, /* 4 */
+			D5                  = 53, /* 5 */
+			D6                  = 54, /* 6 */
+			D7                  = 55, /* 7 */
+			D8                  = 56, /* 8 */
+			D9                  = 57, /* 9 */
 
-		Semicolon           = 59, /* ; */
-		Equal               = 61, /* = */
+			Semicolon           = 59, /* ; */
+			Equal               = 61, /* = */
 
-		A                   = 65,
-		B                   = 66,
-		C                   = 67,
-		D                   = 68,
-		E                   = 69,
-		F                   = 70,
-		G                   = 71,
-		H                   = 72,
-		I                   = 73,
-		J                   = 74,
-		K                   = 75,
-		L                   = 76,
-		M                   = 77,
-		N                   = 78,
-		O                   = 79,
-		P                   = 80,
-		Q                   = 81,
-		R                   = 82,
-		S                   = 83,
-		T                   = 84,
-		U                   = 85,
-		V                   = 86,
-		W                   = 87,
-		X                   = 88,
-		Y                   = 89,
-		Z                   = 90,
+			A                   = 65,
+			B                   = 66,
+			C                   = 67,
+			D                   = 68,
+			E                   = 69,
+			F                   = 70,
+			G                   = 71,
+			H                   = 72,
+			I                   = 73,
+			J                   = 74,
+			K                   = 75,
+			L                   = 76,
+			M                   = 77,
+			N                   = 78,
+			O                   = 79,
+			P                   = 80,
+			Q                   = 81,
+			R                   = 82,
+			S                   = 83,
+			T                   = 84,
+			U                   = 85,
+			V                   = 86,
+			W                   = 87,
+			X                   = 88,
+			Y                   = 89,
+			Z                   = 90,
 
-		LeftBracket         = 91,  /* [ */
-		Backslash           = 92,  /* \ */
-		RightBracket        = 93,  /* ] */
-		GraveAccent         = 96,  /* ` */
+			LeftBracket         = 91,  /* [ */
+			Backslash           = 92,  /* \ */
+			RightBracket        = 93,  /* ] */
+			GraveAccent         = 96,  /* ` */
 
-		World1              = 161, /* non-US #1 */
-		World2              = 162, /* non-US #2 */
+			World1              = 161, /* non-US #1 */
+			World2              = 162, /* non-US #2 */
 
-		/* Function keys */
-		Escape              = 256,
-		Enter               = 257,
-		Tab                 = 258,
-		Backspace           = 259,
-		Insert              = 260,
-		Delete              = 261,
-		Right               = 262,
-		Left                = 263,
-		Down                = 264,
-		Up                  = 265,
-		PageUp              = 266,
-		PageDown            = 267,
-		Home                = 268,
-		End                 = 269,
-		CapsLock            = 280,
-		ScrollLock          = 281,
-		NumLock             = 282,
-		PrintScreen         = 283,
-		Pause               = 284,
-		F1                  = 290,
-		F2                  = 291,
-		F3                  = 292,
-		F4                  = 293,
-		F5                  = 294,
-		F6                  = 295,
-		F7                  = 296,
-		F8                  = 297,
-		F9                  = 298,
-		F10                 = 299,
-		F11                 = 300,
-		F12                 = 301,
-		F13                 = 302,
-		F14                 = 303,
-		F15                 = 304,
-		F16                 = 305,
-		F17                 = 306,
-		F18                 = 307,
-		F19                 = 308,
-		F20                 = 309,
-		F21                 = 310,
-		F22                 = 311,
-		F23                 = 312,
-		F24                 = 313,
-		F25                 = 314,
+			/* Function keys */
+			Escape              = 256,
+			Enter               = 257,
+			Tab                 = 258,
+			Backspace           = 259,
+			Insert              = 260,
+			Delete              = 261,
+			Right               = 262,
+			Left                = 263,
+			Down                = 264,
+			Up                  = 265,
+			PageUp              = 266,
+			PageDown            = 267,
+			Home                = 268,
+			End                 = 269,
+			CapsLock            = 280,
+			ScrollLock          = 281,
+			NumLock             = 282,
+			PrintScreen         = 283,
+			Pause               = 284,
+			F1                  = 290,
+			F2                  = 291,
+			F3                  = 292,
+			F4                  = 293,
+			F5                  = 294,
+			F6                  = 295,
+			F7                  = 296,
+			F8                  = 297,
+			F9                  = 298,
+			F10                 = 299,
+			F11                 = 300,
+			F12                 = 301,
+			F13                 = 302,
+			F14                 = 303,
+			F15                 = 304,
+			F16                 = 305,
+			F17                 = 306,
+			F18                 = 307,
+			F19                 = 308,
+			F20                 = 309,
+			F21                 = 310,
+			F22                 = 311,
+			F23                 = 312,
+			F24                 = 313,
+			F25                 = 314,
 
-		/* Keypad */
-		KP0                 = 320,
-		KP1                 = 321,
-		KP2                 = 322,
-		KP3                 = 323,
-		KP4                 = 324,
-		KP5                 = 325,
-		KP6                 = 326,
-		KP7                 = 327,
-		KP8                 = 328,
-		KP9                 = 329,
-		KPDecimal           = 330,
-		KPDivide            = 331,
-		KPMultiply          = 332,
-		KPSubtract          = 333,
-		KPAdd               = 334,
-		KPEnter             = 335,
-		KPEqual             = 336,
+			/* Keypad */
+			KP0                 = 320,
+			KP1                 = 321,
+			KP2                 = 322,
+			KP3                 = 323,
+			KP4                 = 324,
+			KP5                 = 325,
+			KP6                 = 326,
+			KP7                 = 327,
+			KP8                 = 328,
+			KP9                 = 329,
+			KPDecimal           = 330,
+			KPDivide            = 331,
+			KPMultiply          = 332,
+			KPSubtract          = 333,
+			KPAdd               = 334,
+			KPEnter             = 335,
+			KPEqual             = 336,
 
-		LeftShift           = 340,
-		LeftControl         = 341,
-		LeftAlt             = 342,
-		LeftSuper           = 343,
-		RightShift          = 344,
-		RightControl        = 345,
-		RightAlt            = 346,
-		RightSuper          = 347,
-		Menu                = 348
-	} Key;
-
-	inline std::ostream& operator<<(std::ostream& os, KeyCode keyCode)
-	{
-		os << static_cast<int32_t>(keyCode);
-		return os;
+			LeftShift           = 340,
+			LeftControl         = 341,
+			LeftAlt             = 342,
+			LeftSuper           = 343,
+			RightShift          = 344,
+			RightControl        = 345,
+			RightAlt            = 346,
+			RightSuper          = 347,
+			Menu                = 348
+		};
 	}
+
+	namespace Key = KeyCode;
 }
 
 // From glfw3.h

--- a/Hazel/src/Hazel/Core/MouseCodes.h
+++ b/Hazel/src/Hazel/Core/MouseCodes.h
@@ -2,29 +2,28 @@
 
 namespace Hazel
 {
-	typedef enum class MouseCode : uint16_t
+	namespace MouseCode
 	{
-		// From glfw3.h
-		Button0                = 0,
-		Button1                = 1,
-		Button2                = 2,
-		Button3                = 3,
-		Button4                = 4,
-		Button5                = 5,
-		Button6                = 6,
-		Button7                = 7,
+		enum : uint16_t
+		{
+			// From glfw3.h
+			Button0                = 0,
+			Button1                = 1,
+			Button2                = 2,
+			Button3                = 3,
+			Button4                = 4,
+			Button5                = 5,
+			Button6                = 6,
+			Button7                = 7,
 
-		ButtonLast             = Button7,
-		ButtonLeft             = Button0,
-		ButtonRight            = Button1,
-		ButtonMiddle           = Button2
-	} Mouse;
-	
-	inline std::ostream& operator<<(std::ostream& os, MouseCode mouseCode)
-	{
-		os << static_cast<int32_t>(mouseCode);
-		return os;
+			ButtonLast             = Button7,
+			ButtonLeft             = Button0,
+			ButtonRight            = Button1,
+			ButtonMiddle           = Button2
+		};
 	}
+	
+	namespace Mouse = MouseCode;
 }
 
 #define HZ_MOUSE_BUTTON_0      ::Hazel::Mouse::Button0

--- a/Hazel/src/Hazel/Events/KeyEvent.h
+++ b/Hazel/src/Hazel/Events/KeyEvent.h
@@ -8,23 +8,23 @@ namespace Hazel {
 	class KeyEvent : public Event
 	{
 	public:
-		KeyCode GetKeyCode() const { return m_KeyCode; }
+		uint16_t GetKeyCode() const { return m_KeyCode; }
 
 		EVENT_CLASS_CATEGORY(EventCategoryKeyboard | EventCategoryInput)
 	protected:
-		KeyEvent(KeyCode keycode)
+		KeyEvent(const uint16_t keycode)
 			: m_KeyCode(keycode) {}
 
-		KeyCode m_KeyCode;
+		uint16_t m_KeyCode;
 	};
 
 	class KeyPressedEvent : public KeyEvent
 	{
 	public:
-		KeyPressedEvent(KeyCode keycode, int repeatCount)
+		KeyPressedEvent(const uint16_t keycode, const uint16_t repeatCount)
 			: KeyEvent(keycode), m_RepeatCount(repeatCount) {}
 
-		int GetRepeatCount() const { return m_RepeatCount; }
+		uint16_t GetRepeatCount() const { return m_RepeatCount; }
 
 		std::string ToString() const override
 		{
@@ -35,13 +35,13 @@ namespace Hazel {
 
 		EVENT_CLASS_TYPE(KeyPressed)
 	private:
-		int m_RepeatCount;
+		uint16_t m_RepeatCount;
 	};
 
 	class KeyReleasedEvent : public KeyEvent
 	{
 	public:
-		KeyReleasedEvent(KeyCode keycode)
+		KeyReleasedEvent(const uint16_t keycode)
 			: KeyEvent(keycode) {}
 
 		std::string ToString() const override
@@ -57,7 +57,7 @@ namespace Hazel {
 	class KeyTypedEvent : public KeyEvent
 	{
 	public:
-		KeyTypedEvent(KeyCode keycode)
+		KeyTypedEvent(const uint16_t keycode)
 			: KeyEvent(keycode) {}
 
 		std::string ToString() const override

--- a/Hazel/src/Hazel/Events/MouseEvent.h
+++ b/Hazel/src/Hazel/Events/MouseEvent.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include "Hazel/Events/Event.h"
-#include "Hazel/Core/Input.h"
 
 namespace Hazel {
 
 	class MouseMovedEvent : public Event
 	{
 	public:
-		MouseMovedEvent(float x, float y)
+		MouseMovedEvent(const float x, const float y)
 			: m_MouseX(x), m_MouseY(y) {}
 
 		float GetX() const { return m_MouseX; }
@@ -30,7 +29,7 @@ namespace Hazel {
 	class MouseScrolledEvent : public Event
 	{
 	public:
-		MouseScrolledEvent(float xOffset, float yOffset)
+		MouseScrolledEvent(const float xOffset, const float yOffset)
 			: m_XOffset(xOffset), m_YOffset(yOffset) {}
 
 		float GetXOffset() const { return m_XOffset; }
@@ -52,20 +51,20 @@ namespace Hazel {
 	class MouseButtonEvent : public Event
 	{
 	public:
-		inline MouseCode GetMouseButton() const { return m_Button; }
+		uint16_t GetMouseButton() const { return m_Button; }
 
 		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
 	protected:
-		MouseButtonEvent(MouseCode button)
+		MouseButtonEvent(const uint16_t button)
 			: m_Button(button) {}
 
-		MouseCode m_Button;
+		uint16_t m_Button;
 	};
 
 	class MouseButtonPressedEvent : public MouseButtonEvent
 	{
 	public:
-		MouseButtonPressedEvent(MouseCode button)
+		MouseButtonPressedEvent(const uint16_t button)
 			: MouseButtonEvent(button) {}
 
 		std::string ToString() const override
@@ -81,7 +80,7 @@ namespace Hazel {
 	class MouseButtonReleasedEvent : public MouseButtonEvent
 	{
 	public:
-		MouseButtonReleasedEvent(MouseCode button)
+		MouseButtonReleasedEvent(const uint16_t button)
 			: MouseButtonEvent(button) {}
 
 		std::string ToString() const override

--- a/Hazel/src/Platform/Windows/WindowsInput.cpp
+++ b/Hazel/src/Platform/Windows/WindowsInput.cpp
@@ -6,23 +6,23 @@
 
 namespace Hazel {
 
-	bool Input::IsKeyPressed(KeyCode key)
+	bool Input::IsKeyPressed(const uint16_t key)
 	{
-		auto window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
+		auto* window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
 		auto state = glfwGetKey(window, static_cast<int32_t>(key));
 		return state == GLFW_PRESS || state == GLFW_REPEAT;
 	}
 
-	bool Input::IsMouseButtonPressed(MouseCode button)
+	bool Input::IsMouseButtonPressed(const uint16_t button)
 	{
-		auto window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
+		auto* window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
 		auto state = glfwGetMouseButton(window, static_cast<int32_t>(button));
 		return state == GLFW_PRESS;
 	}
 
-	std::pair<float, float> Input::GetMousePosition()
+	glm::vec2 Input::GetMousePosition()
 	{
-		auto window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
+		auto* window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
 		double xpos, ypos;
 		glfwGetCursorPos(window, &xpos, &ypos);
 
@@ -31,14 +31,12 @@ namespace Hazel {
 
 	float Input::GetMouseX()
 	{
-		auto[x, y] = GetMousePosition();
-		return x;
+		return GetMousePosition().x;
 	}
 
 	float Input::GetMouseY()
 	{
-		auto[x, y] = GetMousePosition();
-		return y;
+		return GetMousePosition().y;
 	}
 
 }

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -94,19 +94,19 @@ namespace Hazel {
 			{
 				case GLFW_PRESS:
 				{
-					KeyPressedEvent event(static_cast<KeyCode>(key), 0);
+					KeyPressedEvent event(key, 0);
 					data.EventCallback(event);
 					break;
 				}
 				case GLFW_RELEASE:
 				{
-					KeyReleasedEvent event(static_cast<KeyCode>(key));
+					KeyReleasedEvent event(key);
 					data.EventCallback(event);
 					break;
 				}
 				case GLFW_REPEAT:
 				{
-					KeyPressedEvent event(static_cast<KeyCode>(key), 1);
+					KeyPressedEvent event(key, 1);
 					data.EventCallback(event);
 					break;
 				}
@@ -117,7 +117,7 @@ namespace Hazel {
 		{
 			WindowData& data = *(WindowData*)glfwGetWindowUserPointer(window);
 
-			KeyTypedEvent event(static_cast<KeyCode>(keycode));
+			KeyTypedEvent event(keycode);
 			data.EventCallback(event);
 		});
 
@@ -129,13 +129,13 @@ namespace Hazel {
 			{
 				case GLFW_PRESS:
 				{
-					MouseButtonPressedEvent event(static_cast<MouseCode>(button));
+					MouseButtonPressedEvent event(button);
 					data.EventCallback(event);
 					break;
 				}
 				case GLFW_RELEASE:
 				{
-					MouseButtonReleasedEvent event(static_cast<MouseCode>(button));
+					MouseButtonReleasedEvent event(button);
 					data.EventCallback(event);
 					break;
 				}

--- a/Hazelnut/imgui.ini
+++ b/Hazelnut/imgui.ini
@@ -21,7 +21,7 @@ Collapsed=0
 DockId=0x00000002,0
 
 [Docking][Data]
-DockSpace   ID=0x3BC79352 Window=0x4647B76E Pos=320,351 Size=1280,701 Split=X Selected=0x995B0CF8
+DockSpace   ID=0x3BC79352 Window=0x4647B76E Pos=86,128 Size=1280,701 Split=X Selected=0x995B0CF8
   DockNode  ID=0x00000001 Parent=0x3BC79352 SizeRef=426,701 Selected=0x1C33C293
   DockNode  ID=0x00000002 Parent=0x3BC79352 SizeRef=852,701 CentralNode=1 HiddenTabBar=1 Selected=0x995B0CF8
 

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -180,7 +180,7 @@ namespace Hazel {
 		m_ViewportSize = { viewportPanelSize.x, viewportPanelSize.y };
 
 		uint32_t textureID = m_Framebuffer->GetColorAttachmentRendererID();
-		ImGui::Image((void*)textureID, ImVec2{ m_ViewportSize.x, m_ViewportSize.y }, ImVec2{ 0, 1 }, ImVec2{ 1, 0 });
+		ImGui::Image(reinterpret_cast<void*>(textureID), ImVec2{ m_ViewportSize.x, m_ViewportSize.y }, ImVec2{ 0, 1 }, ImVec2{ 1, 0 });
 		ImGui::End();
 		ImGui::PopStyleVar();
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -57,7 +57,8 @@ project "Hazel"
 	defines
 	{
 		"_CRT_SECURE_NO_WARNINGS",
-		"GLFW_INCLUDE_NONE"
+		"GLFW_INCLUDE_NONE",
+		"_SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING"
 	}
 
 	includedirs
@@ -116,6 +117,10 @@ project "Sandbox"
 	{
 		"%{prj.name}/src/**.h",
 		"%{prj.name}/src/**.cpp"
+	}
+
+	defines {
+		"_SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING"
 	}
 
 	includedirs


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
This PR solves spdlog warnings about C++17 deprecating `std::result_of`.
This PR will improve existing `Input` system by allowing users to compare directly to `uint16_t`s rather than to `enum class`es

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Other PRs this solves    | #171 (which has been closed)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
This PR improves the `Input` system by allowing the KeyCodes and the MouseCodes to be compared directly to integer types.
Removes a lot of static casting required to use enum classes, as well as the `std::ostream` functions required to log them.
Also changed `Input::GetMousePosition()` to return a `glm::vec2` rather than an `std::pair<float, float>`.

Additionally, the C4996 warning about `std::result_of` being deprecated in C++17 was fixed with a preprocessor define in the `Hazel` and `Sandbox` premake definitions.

#### Additional context
Tested on Windows 10 64-bit.