### PR TITLE
Removed precompiled header includes in header files

### DIFF
--- a/Hazel/src/Hazel/Core/Window.h
+++ b/Hazel/src/Hazel/Core/Window.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "hzpch.h"
+#include <sstream>
 
 #include "Hazel/Core/Base.h"
 #include "Hazel/Events/Event.h"

--- a/Hazel/src/Hazel/Debug/Instrumentor.h
+++ b/Hazel/src/Hazel/Debug/Instrumentor.h
@@ -6,6 +6,10 @@
 #include <iomanip>
 #include <string>
 #include <thread>
+#include <mutex>
+#include <sstream>
+
+#include "Hazel/Core/Log.h"
 
 namespace Hazel {
 

--- a/Hazel/src/Hazel/Events/Event.h
+++ b/Hazel/src/Hazel/Events/Event.h
@@ -1,6 +1,7 @@
 #pragma once
-#include "hzpch.h"
+#include <functional>
 
+#include "Hazel/Debug/Instrumentor.h"
 #include "Hazel/Core/Base.h"
 
 namespace Hazel {


### PR DESCRIPTION
#### Issue
Precompiled header(hzpch.h) include in header files (Window.h, Event.h)

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Replaced the precompiled header with necessary includes
