### PR TITLE
Closing ifstream both if its readable and unreadable

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -68,12 +68,13 @@ namespace Hazel {
 				result.resize(size);
 				in.seekg(0, std::ios::beg);
 				in.read(&result[0], size);
-				in.close();
 			}
 			else
 			{
 				HZ_CORE_ERROR("Could not read from file '{0}'", filepath);
 			}
+
+			in.close();
 		}
 		else
 		{


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
In OpenGLShader.cpp method ReadFile() ifstream isn't closed if we're unable to read from it.

#### PR impact
List of related issues/PRs this will solve:

None

#### Proposed fix 
A short description of what this fix is and how it fixed the issue you described.
