### PR TITLE
Remove redundant .get() in Renderer2D

### DIFF
--- a/Hazel/src/Hazel/Renderer/Renderer2D.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer2D.cpp
@@ -241,7 +241,7 @@ namespace Hazel {
 		float textureIndex = 0.0f;
 		for (uint32_t i = 1; i < s_Data.TextureSlotIndex; i++)
 		{
-			if (*s_Data.TextureSlots[i].get() == *texture.get())
+			if (*s_Data.TextureSlots[i] == *texture)
 			{
 				textureIndex = (float)i;
 				break;


### PR DESCRIPTION
#### Issue
Minor redundant code impacts the sections readability

#### Proposed fix
Remove ".get()" and make use of smart pointers overloaded operators