### PR TITLE
Added discord link as an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Hazel Community Support (Discord)
+    url: https://thecherno.com/discord
+    about: Please ask Hazel related questions in the game-engine-series thread.


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
See #269

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Resolves #269
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
By removing the `Don’t see your issue here? [Open a blank issue](https://github.com/TheCherno/Hazel/issues/new).` we force users to use a template even more. In addition we also add a link to the [Discord server](https://thecherno.com/discord) to prevent users from asking questions here.

#### Additional context
As #269 already mentioned, there is a working implementation already in use in [TheChernoCommunity/HazelWiki](https://github.com/TheChernoCommunity/HazelWiki/issues).