### PR TITLE
Partial Xlib platform support.

### DIFF
--- a/Hazel/src/Platform/Linux-Xlib/XlibInput.cpp
+++ b/Hazel/src/Platform/Linux-Xlib/XlibInput.cpp
@@ -1,0 +1,43 @@
+#include "hzpch.h"
+#include "Hazel/Core/Input.h"
+
+#include "Hazel/Core/Application.h"
+
+namespace Hazel {
+
+	bool Input::IsKeyPressed(KeyCode key)
+	{
+		auto window = static_cast<int*>(Application::Get().GetWindow().GetNativeWindow());
+		auto state = glfwGetKey(window, static_cast<int32_t>(key));
+		return state == GLFW_PRESS || state == GLFW_REPEAT;
+	}
+
+	bool Input::IsMouseButtonPressed(MouseCode button)
+	{
+		auto window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
+		auto state = glfwGetMouseButton(window, static_cast<int32_t>(button));
+		return state == GLFW_PRESS;
+	}
+
+	std::pair<float, float> Input::GetMousePosition()
+	{
+		auto window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
+		double xpos, ypos;
+		glfwGetCursorPos(window, &xpos, &ypos);
+
+		return { (float)xpos, (float)ypos };
+	}
+
+	float Input::GetMouseX()
+	{
+		auto[x, y] = GetMousePosition();
+		return x;
+	}
+
+	float Input::GetMouseY()
+	{
+		auto[x, y] = GetMousePosition();
+		return y;
+	}
+
+}

--- a/Hazel/src/Platform/Linux-Xlib/XlibWindow.cpp
+++ b/Hazel/src/Platform/Linux-Xlib/XlibWindow.cpp
@@ -1,0 +1,198 @@
+#include "hzpch.h"
+#include "Platform/Linux-Xlib/XlibWindow.h"
+
+#include "Hazel/Core/Input.h"
+
+#include "Hazel/Events/ApplicationEvent.h"
+#include "Hazel/Events/MouseEvent.h"
+#include "Hazel/Events/KeyEvent.h"
+
+#include "Hazel/Renderer/Renderer.h"
+
+#include "Platform/OpenGL/OpenGLContext.h"
+
+namespace Hazel {
+	
+	static s_WindowCount = 0;
+
+	XlibWindow::XlibWindow(const WindowProps& props)
+	{
+		HZ_PROFILE_FUNCTION();
+
+		Init(props);
+	}
+
+	XlibWindow::~XlibWindow()
+	{
+		HZ_PROFILE_FUNCTION();
+
+		Shutdown();
+	}
+
+	void CreateContext(GLXFBConfig& fbconfig)
+	{
+		typedef GLXContext (*glXCreateContextAttribsARBProc)(Display*, GLXFBConfig, GLXContext, Bool, const int*);
+
+		glXCreateContextAttribsARBProc glXCreateContextAttribsARB = 0;
+		glXCreateContextAttribsARB = (glXCreateContextAttribsARBProc)glXGetProcAddressARB((const unsigned char*)"glXCreateContextAttribsARB");
+
+		GLXContext context = 0;
+		/* OpenGL 3.3 */
+		int attribs[] =
+		{
+			0x2091, 3,
+			0x2092, 3,
+			None
+		};
+		context = glXCreateContextAttribsARB(dis, fbconfig, 0, True, attribs);
+		
+		/* That should be in OpenGLContext::Init() */
+		glXMakeCurrent(m_Display, m_Window, context);
+	}
+
+	int CreateWindow(int width, int height, const char *title)
+	{
+		/* Check GLX version */
+		
+		GLXFBConfig *fbc;
+		int attribs[] =
+		{
+			GLX_X_RENDERABLE,	True,
+			GLX_DRAWABLE_TYPE,	GLX_WINDOW_BIT,
+			GLX_RENDER_TYPE,		GLX_RGBA_BIT,
+			GLX_X_VISUAL_TYPE,	GLX_TRUE_COLOR,
+			GLX_RED_SIZE,			8,
+			GLX_GREEN_SIZE,		8,
+			GLX_BLUE_SIZE,		8,
+			GLX_ALPHA_SIZE,		8,
+			GLX_DEPTH_SIZE,		24,
+			GLX_STENCIL_SIZE,		8,
+			GLX_DOUBLEBUFFER,	True,
+			None
+		};
+
+		int fb_count;
+		fbc = glXChooseFBConfig(m_Display, DefaultScreen(m_Display), attribs, &fb_count);
+		/* check if fbc = 0 */
+
+		int best_fbc = -1, worst_fbc = -1, best_samp = -1, worst_samp = 999;
+		for (int i = 0; i < fb_count; ++i)
+		{
+			XVisualInfo *tvi = glXGetVisualFromFBConfig(dp->dis, fbc[i]);
+			if (tvi)
+			{
+				int samp_buf, samples;
+				glXGetFBConfigAttrib(m_Display, fbc[i], GLX_SAMPLE_BUFFERS, &samp_buf);
+				glXGetFBConfigAttrib(m_Display, fbc[i], GLX_SAMPLES, &samples);
+				if (best_fbc < 0 || (samp_buf && samples > best_samp))
+				{
+					best_fbc = i;
+					best_samp = samples;
+				}
+				if (worst_fbc < 0 || !samp_buf || samples < worst_samp)
+				{
+					worst_fbc = i;
+					worst_samp = samples;
+				}
+			}
+		}
+		GLXFBConfig best = fbc[best_fbc];
+		XFree(fbc);
+		XVisualInfo *vi = glXGetVisualFromFBConfig(m_Display, best);
+
+		XSetWindowAttributes swa;
+		swa.colomap = XCreateColormap(dp->dis, root, vis, AllocNone);
+		swa.background_pixmap = None;
+		swa.event_mask = ; /* Events */
+
+		int root = XRootWindow(dp->dis, vi->screen);
+
+		XCreateWindow(m_Display, root, 0, 0, width, height, 0, vi->depth, InputOutput, vi->visual, mask, &swa);
+		XStroreName(m_Display, m_Window, title);
+		XMapWindow(m_Display, m_Window);
+
+		XFree(vi);
+
+		CreateContext(best);
+	}
+
+	void XlibWindow::Init(const WindowProps& props)
+	{
+		HZ_PROFILE_FUNCTION();
+
+		m_Data.Title = props.Title;
+		m_Data.Width = props.Width;
+		m_Data.Height = props.Height;
+
+		HZ_CORE_INFO("Creating window {0} ({1}, {2})", props.Title, props.Width, props.Height);
+
+		if (s_WindowCount == 0)
+		{
+			Display *dis = XOpenDisplay(0);
+			if (dis == nullptr)
+			{
+				HZ_CORE_ERROR("Xlib Error: Failed to connect to the X server.");
+			}	
+		}
+
+		{
+		#if defined(HZ_DEBUG)
+			if (Renderer::GetAPI() == RendererAPI::API::OpenGL)
+				bool debug = true;
+		#endif
+			m_Window = CreateWindow((int)props.Width, (int)props.Height, m_Data.Title.c_str());
+			++s_WindowCount;
+		}
+		
+		/* CreateWindow() also calls CreateContext() */
+		/* It's outside the OpenGLContext class because it uses GLFW */
+
+		SetVSync(true);
+	}
+
+	void WindowsWindow::Shutdown()
+	{
+		HZ_PROFILE_FUNCTION();
+
+		XDestroyWindow(m_Display, m_Window);
+		--s_WindowCount;
+
+		if (s_WindowCount == 0)
+		{
+			XCloseDisplay(m_Display);
+		}
+	}
+
+	void WindowsWindow::OnUpdate()
+	{
+		HZ_PROFILE_FUNCTION();
+
+		if (XPending(m_Display))
+		{
+			XNextEvent(m_Display, &m_Event);
+			switch (m_Event.type)
+			{
+ 				/* Handle Events */
+			}
+		}
+		m_Context->SwapBuffers();
+	}
+
+	void WindowsWindow::SetVSync(bool enabled)
+	{
+		HZ_PROFILE_FUNCTION();
+
+		if (enabled)
+			glXSwapInterval();
+		else
+			glXSwapInterval();
+
+		m_Data.VSync = enabled;
+	}
+
+	bool WindowsWindow::IsVSync() const
+	{
+		return m_Data.VSync;
+	}
+
+}

--- a/Hazel/src/Platform/Linux-Xlib/XlibWindow.h
+++ b/Hazel/src/Platform/Linux-Xlib/XlibWindow.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "Hazel/Core/Window.h"
+#include "Hazel/Renderer/GraphicsContext.h"
+
+#include <X11/Xlib.h>
+#include <GL/glx.h>
+
+namespace Hazel {
+
+	class XlibWindow : public Window
+	{
+	public:
+		XlibWindow(const WindowProps& props);
+		virtual ~XlibWindow();
+
+		void OnUpdate() override;
+
+		unsigned int GetWidth() const override { return m_Data.Width; }
+		unsigned int GetHeight() const override { return m_Data.Height; }
+
+		// Window attributes
+		void SetEventCallback(const EventCallbackFn& callback) override { m_Data.EventCallback = callback; }
+		void SetVSync(bool enabled) override;
+		bool IsVSync() const override;
+
+		virtual void* GetNativeWindow() const { return m_Window; }
+	private:
+		virtual void Init(const WindowProps& props);
+		virtual void Shutdown();
+	private:
+		unsigned int m_Window;
+		Scope<GraphicsContext> m_Context;
+
+		struct WindowData
+		{
+			std::string Title;
+			unsigned int Width, Height;
+			bool VSync;
+
+			EventCallbackFn EventCallback;
+		};
+
+		WindowData m_Data;
+		Display *m_Display;
+		XEvent m_Event;
+	};
+
+}


### PR DESCRIPTION
Hi,
I've been making a game engine and I thought that I could also write some code for Hazel. The part I am excited about is Linux/Xlib implementation (XCB is probably better but doesn't have OpenGL support). 
I know it's not a requested feature but I would be very glad if my code would be usable.

What it does:
XlibWindow::init creates an Xlib window and creates an OpenGL 3.3 context for it (omitting OpenGLContext::CreateContext and OpenGLContext::init).

However, it's cannot be built right know because there is an Xlib type Window that is the same as the Hazel name and I think the C++ compiler doesn't like it (I'm sure the C compiler doesn't).

If this code makes sense (probably not) it would be easy to extend it with event handling.

