### PR TITLE
Fixed NativeScriptComponent pessimization and unintentional incorrect conversion

### DIFF
--- a/Hazel/src/Hazel/Scene/Components.h
+++ b/Hazel/src/Hazel/Scene/Components.h
@@ -54,22 +54,22 @@ namespace Hazel {
 	{
 		ScriptableEntity* Instance = nullptr;
 
-		std::function<void()> InstantiateFunction;
-		std::function<void()> DestroyInstanceFunction;
+		void(* InstantiateFunction)(ScriptableEntity*&);
+		void(* DestroyInstanceFunction)(ScriptableEntity*&);
 
-		std::function<void(ScriptableEntity*)> OnCreateFunction;
-		std::function<void(ScriptableEntity*)> OnDestroyFunction;
-		std::function<void(ScriptableEntity*, Timestep)> OnUpdateFunction;
+		void(* OnCreateFunction)(ScriptableEntity*);
+		void(* OnDestroyFunction)(ScriptableEntity*);
+		void(* OnUpdateFunction)(ScriptableEntity*, Timestep);
 
 		template<typename T>
 		void Bind()
 		{
-			InstantiateFunction = [&]() { Instance = new T(); };
-			DestroyInstanceFunction = [&]() { delete (T*)Instance; Instance = nullptr; };
+			InstantiateFunction = [](ScriptableEntity*& instance) { instance = new T(); };
+			DestroyInstanceFunction = [](ScriptableEntity*& instance) { delete static_cast<T*>(instance); instance = nullptr; };
 
-			OnCreateFunction = [](ScriptableEntity* instance) { ((T*)instance)->OnCreate(); };
-			OnDestroyFunction = [](ScriptableEntity* instance) { ((T*)instance)->OnDestroy(); };
-			OnUpdateFunction = [](ScriptableEntity* instance, Timestep ts) { ((T*)instance)->OnUpdate(ts); };
+			OnCreateFunction = [](ScriptableEntity* instance) { static_cast<T*>(instance)->OnCreate(); };
+			OnDestroyFunction = [](ScriptableEntity* instance) { static_cast<T*>(instance)->OnDestroy(); };
+			OnUpdateFunction = [](ScriptableEntity* instance, Timestep ts) { static_cast<T*>(instance)->OnUpdate(ts); };
 		}
 	};
 

--- a/Hazel/src/Hazel/Scene/Components.h
+++ b/Hazel/src/Hazel/Scene/Components.h
@@ -54,12 +54,12 @@ namespace Hazel {
 	{
 		ScriptableEntity* Instance = nullptr;
 
-		void(* InstantiateFunction)(ScriptableEntity*&);
-		void(* DestroyInstanceFunction)(ScriptableEntity*&);
+		void(* InstantiateFunction)(ScriptableEntity*&) = nullptr;
+		void(* DestroyInstanceFunction)(ScriptableEntity*&) = nullptr;
 
-		void(* OnCreateFunction)(ScriptableEntity*);
-		void(* OnDestroyFunction)(ScriptableEntity*);
-		void(* OnUpdateFunction)(ScriptableEntity*, Timestep);
+		void(* OnCreateFunction)(ScriptableEntity*) = nullptr;
+		void(* OnDestroyFunction)(ScriptableEntity*) = nullptr;
+		void(* OnUpdateFunction)(ScriptableEntity*, Timestep) = nullptr;
 
 		template<typename T>
 		void Bind()

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -87,7 +87,7 @@ namespace Hazel {
 			auto view = m_Registry.view<TransformComponent, CameraComponent>();
 			for (auto entity : view)
 			{
-				auto& [transform, camera] = view.get<TransformComponent, CameraComponent>(entity);
+				auto [transform, camera] = view.get<TransformComponent, CameraComponent>(entity);
 				
 				if (camera.Primary)
 				{
@@ -105,7 +105,7 @@ namespace Hazel {
 			auto group = m_Registry.group<TransformComponent>(entt::get<SpriteRendererComponent>);
 			for (auto entity : group)
 			{
-				auto& [transform, sprite] = group.get<TransformComponent, SpriteRendererComponent>(entity);
+				auto [transform, sprite] = group.get<TransformComponent, SpriteRendererComponent>(entity);
 
 				Renderer2D::DrawQuad(transform, sprite.Color);
 			}

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -68,7 +68,7 @@ namespace Hazel {
 			{
 				if (!nsc.Instance)
 				{
-					nsc.InstantiateFunction();
+					nsc.InstantiateFunction(nsc.Instance);
 					nsc.Instance->m_Entity = Entity{ entity, this };
 
 					if (nsc.OnCreateFunction)


### PR DESCRIPTION
## Describe the issue
See #303. Also there're two places in "Scene.cpp" where unintentional incorrect rvalue to non-const lvalue conversions have been made. More on this issue later.

## PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Resolves #303

## Proposed fix
NativeScriptComponent uses `std::function` which introduces unnecessary overhead. This PR fixes it by replacing the `std::function` objects with function pointers.

The second commit fixes a compile error under "/permissive-" in MSVC.

## Additional context
In Line 90 and 108 of Scene.cpp, I think Cherno's intention was to unpack the result using structured binding into two lvalue references, thus the `auto&`.
https://github.com/TheCherno/Hazel/blob/3177aca930a1cdd74bad082a80fb2fbfa27429a2/Hazel/src/Hazel/Scene/Scene.cpp#L90 https://github.com/TheCherno/Hazel/blob/3177aca930a1cdd74bad082a80fb2fbfa27429a2/Hazel/src/Hazel/Scene/Scene.cpp#L108

But actually that `auto&` corresponds to the return value, which is a `std::tuple<TransformComponent&, CameraComponent&>`, and since you cannot assign a return value into a non-const lvalue reference this should fail to compile (see [this cppreference link](https://en.cppreference.com/w/cpp/language/structured_binding#Notes) for detailed explanation).

MSVC compiles fine because it has an extension to make this not an error, but this is obviously non-portable (and not useful either). The original intention here would be "store the result tuple here and then unpack the two references", thus `auto` without the ampersand should be used here. (Also `const auto&` can be used here as well but why that works relates to lifetime extension rules which is another can of worms...).

I also would like to suggest to turn "/permissive-" on in MSVC builds to prevent this kind of problems, but I'm not a premake expert so I don't know the exact changes to make in the build script...

EDIT by @LovelySanta: Added a little help since @Chlorie didn't know how to get code permalinks working in a PR. (You have to link the code line at a specific commit and not just at the head of a branch.)