### PR TITLE
Added #undef min and #undef max to pch file

### DIFF
--- a/Hazel/src/hzpch.h
+++ b/Hazel/src/hzpch.h
@@ -18,5 +18,7 @@
 #include "Hazel/Debug/Instrumentor.h"
 
 #ifdef HZ_PLATFORM_WINDOWS
+	#undef min
+	#undef max
 	#include <Windows.h>
 #endif


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
While compiling the project, especially on Windows, a bunch of compilation errors turn up. A quick check on the internet revealed conflicts with the Windows.h header library and std::max and std::min functions being used (in this case the entt library is using std::max)

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Added #undef min and #undef max in the pre-compiled header. (It could be anywhere, for this fix I have added it in the pch file
just above #include <Windows.h> line)
