### PR TITLE
Small OpenGLVertexArray::AddVertexBuffer fix

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -100,7 +100,7 @@ namespace Hazel {
 							ShaderDataTypeToOpenGLBaseType(element.Type),
 							element.Normalized ? GL_TRUE : GL_FALSE,
 							layout.GetStride(),
-							(const void*)(sizeof(float) * count * i));
+							(const void*)(element.Offset + sizeof(float) * count * i));
 						glVertexAttribDivisor(m_VertexBufferIndex, 1);
 						m_VertexBufferIndex++;
 					}


### PR DESCRIPTION
I think I found a little bug in this method. There was element offset missing in pointer calculation.