### PR TITLE
Add uniform location cache for performance.

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -204,8 +204,9 @@ namespace Hazel {
 	{
 		HZ_PROFILE_FUNCTION();
 
-		if (m_UniformLocationCache.find(name) != m_UniformLocationCache.end())
-			return m_UniformLocationCache[name];
+		auto cachedLocation = m_UniformLocationCache.find(name);
+		if (cachedLocation != m_UniformLocationCache.end())
+			return cachedLocation->second;
 
 		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
 		m_UniformLocationCache[name] = location;

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -200,6 +200,18 @@ namespace Hazel {
 		glUseProgram(0);
 	}
 
+	GLint OpenGLShader::GetUniformLocation(const std::string& name) const
+	{
+		HZ_PROFILE_FUNCTION();
+
+		if (m_UniformLocationCache.find(name) != m_UniformLocationCache.end())
+			return m_UniformLocationCache[name];
+
+		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		m_UniformLocationCache[name] = location;
+		return location;
+	}
+
 	void OpenGLShader::SetInt(const std::string& name, int value)
 	{
 		HZ_PROFILE_FUNCTION();
@@ -242,49 +254,49 @@ namespace Hazel {
 
 	void OpenGLShader::UploadUniformInt(const std::string& name, int value)
 	{
-		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		GLint location = GetUniformLocation(name);
 		glUniform1i(location, value);
 	}
 
 	void OpenGLShader::UploadUniformIntArray(const std::string& name, int* values, uint32_t count)
 	{
-		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		GLint location = GetUniformLocation(name);
 		glUniform1iv(location, count, values);
 	}
 
 	void OpenGLShader::UploadUniformFloat(const std::string& name, float value)
 	{
-		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		GLint location = GetUniformLocation(name);
 		glUniform1f(location, value);
 	}
 
 	void OpenGLShader::UploadUniformFloat2(const std::string& name, const glm::vec2& value)
 	{
-		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		GLint location = GetUniformLocation(name);
 		glUniform2f(location, value.x, value.y);
 	}
 
 	void OpenGLShader::UploadUniformFloat3(const std::string& name, const glm::vec3& value)
 	{
-		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		GLint location = GetUniformLocation(name);
 		glUniform3f(location, value.x, value.y, value.z);
 	}
 
 	void OpenGLShader::UploadUniformFloat4(const std::string& name, const glm::vec4& value)
 	{
-		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		GLint location = GetUniformLocation(name);
 		glUniform4f(location, value.x, value.y, value.z, value.w);
 	}
 
 	void OpenGLShader::UploadUniformMat3(const std::string& name, const glm::mat3& matrix)
 	{
-		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		GLint location = GetUniformLocation(name);
 		glUniformMatrix3fv(location, 1, GL_FALSE, glm::value_ptr(matrix));
 	}
 
 	void OpenGLShader::UploadUniformMat4(const std::string& name, const glm::mat4& matrix)
 	{
-		GLint location = glGetUniformLocation(m_RendererID, name.c_str());
+		GLint location = GetUniformLocation(name);
 		glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(matrix));
 	}
 

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <unordered_map>
+
 #include "Hazel/Renderer/Shader.h"
 #include <glm/glm.hpp>
 
 // TODO: REMOVE!
 typedef unsigned int GLenum;
+typedef int GLint;
 
 namespace Hazel {
 
@@ -41,9 +44,11 @@ namespace Hazel {
 		std::string ReadFile(const std::string& filepath);
 		std::unordered_map<GLenum, std::string> PreProcess(const std::string& source);
 		void Compile(const std::unordered_map<GLenum, std::string>& shaderSources);
+		GLint GetUniformLocation(const std::string& name) const;
 	private:
 		uint32_t m_RendererID;
 		std::string m_Name;
+		mutable std::unordered_map<std::string, GLint> m_UniformLocationCache;
 	};
 
 }


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Currently uniform locations are not cached, due to uniforms being constantly looked up, this can save lots of performance overhead. Cherno has talked about wanting to cache uniforms for a while now and this is a simple implementation of this.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
My proposed fix for this is creating a function named ``GetUniformLocation`` which will return a ``GLint``, due to Glad not being included in the header file, I am currently just doing a typedef for ``GLint``, I have also categorized this under the TODO comment stating to remove the typedef's. 

The implementation is straight forward but basically all that is done is an unordered map is created, the key for it is the name, and the value is the GLint location; then the ``GetUniformLocation(const std::string& name)`` function will check if the name is in the cache, if so it returns that from the cache, if it's not in the cache it will retrieve the uniform location and add it to the cache.

I have marked the function as const because it will only retrieve the uniform location and it's not modifying the shader, due to it being const I make the unordered map "mutable" so that the unordered map can be modified by a const function, my reasoning for this being marked as const is because the actual operation of the function is to read the location of the uniform - basically the underlying implementation caches the value but obviously that isn't important to the caller since it's not modifying the shader at all.
