### PR TITLE
optimized way to check for OpenGL version in OpenGLContext.cpp

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLContext.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLContext.cpp
@@ -25,14 +25,7 @@ namespace Hazel {
 		HZ_CORE_INFO("  Renderer: {0}", glGetString(GL_RENDERER));
 		HZ_CORE_INFO("  Version: {0}", glGetString(GL_VERSION));
 
-	#ifdef HZ_ENABLE_ASSERTS
-		int versionMajor;
-		int versionMinor;
-		glGetIntegerv(GL_MAJOR_VERSION, &versionMajor);
-		glGetIntegerv(GL_MINOR_VERSION, &versionMinor);
-
-		HZ_CORE_ASSERT(versionMajor > 4 || (versionMajor == 4 && versionMinor >= 5), "Hazel requires at least OpenGL version 4.5!");
-	#endif
+		HZ_CORE_ASSERT(GLVersion.major > 4 || (GLVersion.major == 4 && GLVersion.minor >= 5), "Hazel requires at least OpenGL version 4.5!");
 	}
 
 	void OpenGLContext::SwapBuffers()


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Not an issue ... just a little code optimization.

Inside OpenGLContext.cpp we check for the OpenGL version using unnecessary OpenGL calls. GLAD already provides us with that information inside the GLVersion struct it creates.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Use the GLVersion struct provided by GLAD instead of the OpenGL version calls.

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.
