### PR TITLE
Renderer fix

### DIFF
--- a/Hazel/src/Hazel/Renderer/Renderer2D.cpp
+++ b/Hazel/src/Hazel/Renderer/Renderer2D.cpp
@@ -198,7 +198,7 @@ namespace Hazel {
 		glm::mat4 transform = glm::translate(glm::mat4(1.0f), position)
 			* glm::scale(glm::mat4(1.0f), { size.x, size.y, 1.0f });
 
-		DrawQuad(transform, texture, tilingFactor);
+		DrawQuad(transform, texture, tilingFactor, tintColor);
 	}
 
 	void Renderer2D::DrawQuad(const glm::mat4& transform, const glm::vec4& color)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The `DrawQuad` function does not use the `tintColor` parameter.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Added the `tintColor` parameter into the function call.
