### PR TITLE
Removed redundant GetProjection()

### DIFF
--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -100,7 +100,7 @@ namespace Hazel {
 
 		if (mainCamera)
 		{
-			Renderer2D::BeginScene(mainCamera->GetProjection(), *cameraTransform);
+			Renderer2D::BeginScene(*mainCamera, *cameraTransform);
 
 			auto group = m_Registry.group<TransformComponent>(entt::get<SpriteRendererComponent>);
 			for (auto entity : group)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
In `Scene.cpp`, while beginning the scene, the camera'a projection is sent, even though the function requires a `Camera` instance. This creates an unnecessary construction and copy.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Giving the `*mainCamera` instead of `mainCamera->GetProjection()` in the `Renderer2D::BeginScene()` function.
