### PR TITLE
Fixed two includes to fit the convention and one typo

### DIFF
--- a/Hazel/src/Hazel/Renderer/Framebuffer.cpp
+++ b/Hazel/src/Hazel/Renderer/Framebuffer.cpp
@@ -1,5 +1,5 @@
 #include "hzpch.h"
-#include "Framebuffer.h"
+#include "Hazel/Renderer/Framebuffer.h"
 
 #include "Hazel/Renderer/Renderer.h"
 

--- a/Hazel/src/Platform/OpenGL/OpenGLFramebuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLFramebuffer.cpp
@@ -1,5 +1,5 @@
 #include "hzpch.h"
-#include "OpenGLFramebuffer.h"
+#include "Platform/OpenGL/OpenGLFramebuffer.h"
 
 #include <glad/glad.h>
 

--- a/Hazel/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -32,7 +32,7 @@ namespace Hazel {
 		stbi_set_flip_vertically_on_load(1);
 		stbi_uc* data = nullptr;
 		{
-			HZ_PROFILE_SCOPE("stbi_load - OpenGLTexture2D::OpenGLTexture2D(const std:string&)");
+			HZ_PROFILE_SCOPE("stbi_load - OpenGLTexture2D::OpenGLTexture2D(const std::string&)");
 			data = stbi_load(path.c_str(), &width, &height, &channels, 0);
 		}
 		HZ_CORE_ASSERT(data, "Failed to load image!");


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Includes in Framebuffer.cpp and OpenGLFramebuffer.cpp did not match the convention to include the whole path.
Fixed one typo in OpenGLTexture for the profile scope.

#### Proposed fix
Changed the includes and the typo.
