### PR TITLE
Moves all Log.h inclusion to Base.h

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -1,8 +1,6 @@
 #include "hzpch.h"
 #include "Hazel/Core/Application.h"
 
-#include "Hazel/Core/Log.h"
-
 #include "Hazel/Renderer/Renderer.h"
 
 #include "Hazel/Core/Input.h"

--- a/Hazel/src/Hazel/Core/Base.h
+++ b/Hazel/src/Hazel/Core/Base.h
@@ -42,7 +42,6 @@ namespace Hazel {
 
 }
 
-#ifndef LOG_H
 	#include "Hazel/Core/Log.h"
 
 	// TODO: Make this macro able to take in no arguments except condition
@@ -53,4 +52,3 @@ namespace Hazel {
 		#define HZ_ASSERT(x, ...)
 		#define HZ_CORE_ASSERT(x, ...)
 	#endif
-#endif // !LOG_H

--- a/Hazel/src/Hazel/Core/Base.h
+++ b/Hazel/src/Hazel/Core/Base.h
@@ -18,15 +18,6 @@
 	#define HZ_DEBUGBREAK()
 #endif
 
-// TODO: Make this macro able to take in no arguments except condition
-#ifdef HZ_ENABLE_ASSERTS
-	#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
-	#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
-#else
-	#define HZ_ASSERT(x, ...)
-	#define HZ_CORE_ASSERT(x, ...)
-#endif
-
 #define BIT(x) (1 << x)
 
 #define HZ_BIND_EVENT_FN(fn) [this](auto&&... args) -> decltype(auto) { return this->fn(std::forward<decltype(args)>(args)...); }
@@ -50,3 +41,16 @@ namespace Hazel {
 	}
 
 }
+
+#ifndef LOG_H
+	#include "Hazel/Core/Log.h"
+
+	// TODO: Make this macro able to take in no arguments except condition
+	#ifdef HZ_ENABLE_ASSERTS
+		#define HZ_ASSERT(x, ...) { if(!(x)) { HZ_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
+		#define HZ_CORE_ASSERT(x, ...) { if(!(x)) { HZ_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); HZ_DEBUGBREAK(); } }
+	#else
+		#define HZ_ASSERT(x, ...)
+		#define HZ_CORE_ASSERT(x, ...)
+	#endif
+#endif // !LOG_H

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Base.h"
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -1,5 +1,4 @@
 #pragma once
-#define LOG_H
 
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -1,6 +1,5 @@
 #pragma once
-
-#include "Hazel/Core/Base.h"
+#define LOG_H
 
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>

--- a/Hazelnut/src/Panels/SceneHierarchyPanel.h
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Hazel/Core/Base.h"
-#include "Hazel/Core/Log.h"
 #include "Hazel/Scene/Scene.h"
 #include "Hazel/Scene/Entity.h"
 


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The issue have been made: #326.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | solves #326

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
The fix consists of two step:
- Adds `#define LOG_H` in `Log.h` to act as header guard.
- Includes `Log.h` in `Base.h` *after* the definition of `Hazel::Ref`.

#### Additional context
As @LovelySanta said, `Log.h` should be included in `Base.h`. However `Log.h` also includes `Base.h`, resulted in a circular inclusion. Since `Log.h` only needs the custom reference system `Hazel::Ref` defined in `Base.h`, I moved the inclusion of `Log.h` to *after* that definition so by the time `Log.h` is included, `Hazel::Ref` is already defined and ready to be used.