### PR TITLE
Add EventCategoryMouseButton to MouseButtonEvent

### DIFF
--- a/Hazel/src/Hazel/Events/MouseEvent.h
+++ b/Hazel/src/Hazel/Events/MouseEvent.h
@@ -54,7 +54,7 @@ namespace Hazel {
 	public:
 		MouseCode GetMouseButton() const { return m_Button; }
 
-		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput | EventCategoryMouseButton)
 	protected:
 		MouseButtonEvent(const MouseCode button)
 			: m_Button(button) {}


### PR DESCRIPTION
`EventCategoryMouseButton` is not being used by any Event.
I think `MouseButtonEvent` should be an `EventCategoryMouseButton`. We can alternatively get rid of it