### PR TITLE
Removed decltype(auto) annotation in HZ_BIND_EVENT_FN lambda

### DIFF
--- a/Hazel/src/Hazel/Core/Base.h
+++ b/Hazel/src/Hazel/Core/Base.h
@@ -29,7 +29,7 @@
 
 #define BIT(x) (1 << x)
 
-#define HZ_BIND_EVENT_FN(fn) [this](auto&&... args) -> decltype(auto) { return this->fn(std::forward<decltype(args)>(args)...); }
+#define HZ_BIND_EVENT_FN(fn) [this](auto&&... args) { return this->fn(std::forward<decltype(args)>(args)...); }
 
 namespace Hazel {
 


### PR DESCRIPTION
I removed the "-> decltype(auto)" to reduce code complexity. The return type can be deduced since C++14, which should not make any problems since Hazel is using C++17.