### PR TITLE
Use std::regex for shader processing

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -86,27 +86,22 @@ namespace Hazel {
 	{
 		HZ_PROFILE_FUNCTION();
 
-		std::unordered_map<GLenum, std::string> shaderSources;
+        std::unordered_map<GLenum, std::string> shaderSources;
+        std::regex typeRegex{"#type "};
+        std::sregex_token_iterator i(source.begin(), source.end(), typeRegex, -1);
+        std::sregex_token_iterator end;
 
-		const char* typeToken = "#type";
-		size_t typeTokenLength = strlen(typeToken);
-		size_t pos = source.find(typeToken, 0); //Start of shader type declaration line
-		while (pos != std::string::npos)
-		{
-			size_t eol = source.find_first_of("\r\n", pos); //End of shader type declaration line
-			HZ_CORE_ASSERT(eol != std::string::npos, "Syntax error");
-			size_t begin = pos + typeTokenLength + 1; //Start of shader type name (after "#type " keyword)
-			std::string type = source.substr(begin, eol - begin);
-			HZ_CORE_ASSERT(ShaderTypeFromString(type), "Invalid shader type specified");
+        while (i != end) {
+            std::string a = *(i++);
+            if (a.empty()) continue;
+            size_t eol = a.find_first_of('\n', 0);
+            auto shaderType = a.substr(0, eol);
+            auto shaderCode = a.substr(eol, a.size() - 1);
+            HZ_CORE_ASSERT(ShaderTypeFromString(shaderType), "Invalid shader type specified");
+            shaderSources[ShaderTypeFromString(shaderType)] = shaderCode;
+        }
 
-			size_t nextLinePos = source.find_first_not_of("\r\n", eol); //Start of shader code after shader type declaration line
-			HZ_CORE_ASSERT(nextLinePos != std::string::npos, "Syntax error");
-			pos = source.find(typeToken, nextLinePos); //Start of next shader type declaration line
-
-			shaderSources[ShaderTypeFromString(type)] = (pos == std::string::npos) ? source.substr(nextLinePos) : source.substr(nextLinePos, pos - nextLinePos);
-		}
-
-		return shaderSources;
+        return shaderSources;
 	}
 
 	void OpenGLShader::Compile(const std::unordered_map<GLenum, std::string>& shaderSources)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Just watched the episode on [Shader asset Files](https://www.youtube.com/watch?v=8wFEzIYRZXg&list=PLlrATfBNZ98dC-V-N3m0Go4deliWHPFwT&index=44) and found the shader parsing code a bit hard to follow.

I'm using `std::regex` in this PR.  I'm relatively new to CPP I'm not sure of the performance impact this might introduce (the original code is already doing a lot of relatively expensive string search operations anyways, but still something to keep in mind)
I think this PR makes the code a little bit more readable, wdty?
