### PR TITLE
Removed warnings from External Dependencies

### DIFF
--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -2,8 +2,12 @@
 
 #include "Hazel/Core/Base.h"
 
+// This ignores all warnings raised inside External headers
+#pragma warning( push, 0)
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
+#pragma warning(pop)
+
 
 namespace Hazel {
 

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -3,7 +3,7 @@
 #include "Hazel/Core/Base.h"
 
 // This ignores all warnings raised inside External headers
-#pragma warning( push, 0)
+#pragma warning(push, 0)
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 #pragma warning(pop)


### PR DESCRIPTION
### There are lot of compiler warnings from External Headers (spdlog and fmt)
Before Changes
---
![image](https://user-images.githubusercontent.com/11287393/94909987-a5b16e00-04c1-11eb-8cb3-0c1c5b54da21.png)

After Changes
---
![image](https://user-images.githubusercontent.com/11287393/94910248-148ec700-04c2-11eb-99d2-13003f9760e5.png)


#### This Pull request will not have any impact on the functionality of Hazel Engine. 
It will just suppress all warnings arising from the external headers. 
1. spdlog/spdlog.h
2. spdlog/fmt/ostr.h

#### This solution to suppress warning can be found on stackoverflow.
https://stackoverflow.com/a/2541990/9271231
