### PR TITLE
Fix EventDispatcher::Dispatch() resetting Event::Handled to false

### DIFF
--- a/Hazel/src/Hazel/Events/Event.h
+++ b/Hazel/src/Hazel/Events/Event.h
@@ -68,7 +68,7 @@ namespace Hazel {
 		{
 			if (m_Event.GetEventType() == T::GetStaticType())
 			{
-				m_Event.Handled = func(static_cast<T&>(m_Event));
+				m_Event.Handled |= func(static_cast<T&>(m_Event));
 				return true;
 			}
 			return false;


### PR DESCRIPTION
Once an event has been handled, it shouldn't get `Event::Handled` set back to false, but currently `EventDispatcher::Dispatch()` does this.

**Repro**
```
// In a Foo::OnEvent(Hazel::Event& e)
Hazel::EventDispatcher dispatcher(e);
dispatcher.Dispatch<Hazel::KeyPressedEvent>([](Hazel::KeyPressedEvent& e) {
	HZ_INFO("1 KeyPressedEvent Handled: {0}", e.Handled);
	return true;
});
dispatcher.Dispatch<Hazel::KeyPressedEvent>([](Hazel::KeyPressedEvent& e) {
	HZ_INFO("2 KeyPressedEvent Handled: {0}", e.Handled);
	return false;
});
dispatcher.Dispatch<Hazel::KeyPressedEvent>([](Hazel::KeyPressedEvent& e) {
	HZ_INFO("3 KeyPressedEvent Handled: {0}", e.Handled);
	return false;
});
```

**Expected Behaviour**
The first lambda should log handled = false, and all subsequent should log handled = true
```
1 KeyPressedEvent Handled: false
2 KeyPressedEvent Handled: true
3 KeyPressedEvent Handled: true
```

**Actual Behaviour**
Returning false from the second lambda incorrectly resets e.Handled to false
```
1 KeyPressedEvent Handled: false
2 KeyPressedEvent Handled: true
3 KeyPressedEvent Handled: false
```

**Fix**
By using `|=` instead of `=`, once `m_Event.Handled` has been set to true, it'll never be reset to false.