### PR TITLE
Removed and replaced code with equivalent standard library function

### DIFF
--- a/Hazel/src/Hazel/Core/Assert.h
+++ b/Hazel/src/Hazel/Core/Assert.h
@@ -2,30 +2,15 @@
 
 #include "Hazel/Core/Base.h"
 #include "Hazel/Core/Log.h"
+#include <filesystem>
 
 #ifdef HZ_ENABLE_ASSERTS
-
-	namespace Hazel::Assert
-	{
-		// Returns the simple file name rather than full path as suggested by LovelySanta
-		constexpr const char* CurrentFileName(const char* path) {
-				const char* file = path;
-				while (*path)
-				{
-					if (*path == '/' || *path == '\\')
-						file = ++path;
-					else
-						path++;
-				}
-				return file;
-			}
-	}
 
 	// Alteratively we could use the same "default" message for both "WITH_MSG" and "NO_MSG" and
 	// provide support for custom formatting by concatenating the formatting string instead of having the format inside the default message
 	#define HZ_INTERNAL_ASSERT_IMPL(type, check, msg, ...) { if(!(check)) { HZ##type##ERROR(msg, __VA_ARGS__); HZ_DEBUGBREAK(); } }
 	#define HZ_INTERNAL_ASSERT_WITH_MSG(type, check, ...) HZ_INTERNAL_ASSERT_IMPL(type, check, "Assertion failed: {0}", __VA_ARGS__)
-	#define HZ_INTERNAL_ASSERT_NO_MSG(type, check) HZ_INTERNAL_ASSERT_IMPL(type, check, "Assertion '{0}' failed at {1}:{2}", HZ_STRINGIFY_MACRO(check), ::Hazel::Assert::CurrentFileName(__FILE__), __LINE__)
+	#define HZ_INTERNAL_ASSERT_NO_MSG(type, check) HZ_INTERNAL_ASSERT_IMPL(type, check, "Assertion '{0}' failed at {1}:{2}", HZ_STRINGIFY_MACRO(check), std::filesystem::path(__FILE__).filename(), __LINE__)
 
 	#define HZ_INTERNAL_ASSERT_GET_MACRO_NAME(arg1, arg2, macro, ...) macro
 	#define HZ_INTERNAL_ASSERT_GET_MACRO(...) HZ_EXPAND_MACRO( HZ_INTERNAL_ASSERT_GET_MACRO_NAME(__VA_ARGS__, HZ_INTERNAL_ASSERT_WITH_MSG, HZ_INTERNAL_ASSERT_NO_MSG) )

--- a/Hazel/src/Hazel/Core/Assert.h
+++ b/Hazel/src/Hazel/Core/Assert.h
@@ -10,7 +10,7 @@
 	// provide support for custom formatting by concatenating the formatting string instead of having the format inside the default message
 	#define HZ_INTERNAL_ASSERT_IMPL(type, check, msg, ...) { if(!(check)) { HZ##type##ERROR(msg, __VA_ARGS__); HZ_DEBUGBREAK(); } }
 	#define HZ_INTERNAL_ASSERT_WITH_MSG(type, check, ...) HZ_INTERNAL_ASSERT_IMPL(type, check, "Assertion failed: {0}", __VA_ARGS__)
-	#define HZ_INTERNAL_ASSERT_NO_MSG(type, check) HZ_INTERNAL_ASSERT_IMPL(type, check, "Assertion '{0}' failed at {1}:{2}", HZ_STRINGIFY_MACRO(check), std::filesystem::path(__FILE__).filename(), __LINE__)
+	#define HZ_INTERNAL_ASSERT_NO_MSG(type, check) HZ_INTERNAL_ASSERT_IMPL(type, check, "Assertion '{0}' failed at {1}:{2}", HZ_STRINGIFY_MACRO(check), std::filesystem::path(__FILE__).filename().string(), __LINE__)
 
 	#define HZ_INTERNAL_ASSERT_GET_MACRO_NAME(arg1, arg2, macro, ...) macro
 	#define HZ_INTERNAL_ASSERT_GET_MACRO(...) HZ_EXPAND_MACRO( HZ_INTERNAL_ASSERT_GET_MACRO_NAME(__VA_ARGS__, HZ_INTERNAL_ASSERT_WITH_MSG, HZ_INTERNAL_ASSERT_NO_MSG) )


### PR DESCRIPTION
A Hazel contributor created a function that has a Standard C++ Library implementation. This patch removes the custom work and swaps in `std::filesystem::path` for appropriate use.

I tested this patch outside of the context of Hazel. @LovelySanta Please test this fix in Visual Studio before accepting!