### PR TITLE
Fix imgui crash in Hazelnut

### DIFF
--- a/Hazelnut/imgui.ini
+++ b/Hazelnut/imgui.ini
@@ -52,4 +52,3 @@ DockSpace     ID=0x3BC79352 Window=0x4647B76E Pos=196,206 Size=1877,973 Split=X 
   DockNode    ID=0x00000002 Parent=0x3BC79352 SizeRef=1275,701 Split=X
     DockNode  ID=0x00000003 Parent=0x00000002 SizeRef=958,701 CentralNode=1 HiddenTabBar=1 Selected=0x995B0CF8
     DockNode  ID=0x00000004 Parent=0x00000002 SizeRef=272,701 Selected=0x1C33C293
-    DockNode  ID=0x00000004 Parent=0x00000002 SizeRef=272,701 Selected=0x1C33C293


### PR DESCRIPTION
Due to a bad merge, a line the imgui.ini file for Hazelnut was duplicated, causing Imgui to crash on startup. This PR removes the duplicated line so Hazelnut runs again. 