### PR TITLE
Added a default extension string

### DIFF
--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -9,7 +9,6 @@
 #include "Hazel/Core/Application.h"
 
 namespace Hazel {
-
 	std::string FileDialogs::OpenFile(const char* filter)
 	{
 		OPENFILENAMEA ofn;
@@ -40,6 +39,7 @@ namespace Hazel {
 		ofn.nMaxFile = sizeof(szFile);
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
+		ofn.lpstrDefExt = ".hazel";
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
 		if (GetSaveFileNameA(&ofn) == TRUE)
 		{
@@ -47,5 +47,4 @@ namespace Hazel {
 		}
 		return std::string();
 	}
-
 }

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -1,6 +1,7 @@
 #include "hzpch.h"
 #include "Hazel/Utils/PlatformUtils.h"
 
+#include <sstream>
 #include <commdlg.h>
 #include <GLFW/glfw3.h>
 #define GLFW_EXPOSE_NATIVE_WIN32
@@ -40,7 +41,19 @@ namespace Hazel {
 		ofn.nMaxFile = sizeof(szFile);
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
-		ofn.lpstrDefExt = ".hazel";
+
+		// Sets the default extension by extracting it from the filter
+		std::string filterString(filter);
+		std::stringstream s(filterString);
+		std::string defaultExtension;
+
+		while (s >> defaultExtension) {
+			if (defaultExtension.find('*') < defaultExtension.length()) {
+				ofn.lpstrDefExt = defaultExtension.c_str();
+			}
+		}
+		//
+
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
 		if (GetSaveFileNameA(&ofn) == TRUE)
 		{

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -9,10 +9,10 @@
 
 #include "Hazel/Core/Application.h"
 
-namespace Hazel {
+namespace Hazel
+{
 	
-	std::string FileDialogs::OpenFile(const char* filter)
-	{
+	std::string FileDialogs::OpenFile(const char* filter) {
 		OPENFILENAMEA ofn;
 		CHAR szFile[260] = { 0 };
 		ZeroMemory(&ofn, sizeof(OPENFILENAME));
@@ -23,15 +23,13 @@ namespace Hazel {
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
-		if (GetOpenFileNameA(&ofn) == TRUE)
-		{
+		if (GetOpenFileNameA(&ofn) == TRUE) {
 			return ofn.lpstrFile;
 		}
 		return std::string();
 	}
 
-	std::string FileDialogs::SaveFile(const char* filter)
-	{
+	std::string FileDialogs::SaveFile(const char* filter) {
 		OPENFILENAMEA ofn;
 		CHAR szFile[260] = { 0 };
 		ZeroMemory(&ofn, sizeof(OPENFILENAME));
@@ -43,23 +41,13 @@ namespace Hazel {
 		ofn.nFilterIndex = 1;
 
 		// Sets the default extension by extracting it from the filter
-		std::string filterString(filter);
-		std::stringstream s(filterString);
-		std::string defaultExtension;
-
-		while (s >> defaultExtension) {
-			if (defaultExtension.find('*') < defaultExtension.length()) {
-				ofn.lpstrDefExt = defaultExtension.c_str();
-			}
-		}
-		//
+		ofn.lpstrDefExt = strchr(filter, '\0') + 1;
 
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
-		if (GetSaveFileNameA(&ofn) == TRUE)
-		{
+		if (GetSaveFileNameA(&ofn) == TRUE) {
 			return ofn.lpstrFile;
 		}
 		return std::string();
 	}
 	
-}
+} // namespace Hazel

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -9,6 +9,7 @@
 #include "Hazel/Core/Application.h"
 
 namespace Hazel {
+	
 	std::string FileDialogs::OpenFile(const char* filter)
 	{
 		OPENFILENAMEA ofn;
@@ -47,4 +48,5 @@ namespace Hazel {
 		}
 		return std::string();
 	}
+	
 }

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -9,10 +9,10 @@
 
 #include "Hazel/Core/Application.h"
 
-namespace Hazel
-{
+namespace Hazel {
 	
-	std::string FileDialogs::OpenFile(const char* filter) {
+	std::string FileDialogs::OpenFile(const char* filter)
+	{
 		OPENFILENAMEA ofn;
 		CHAR szFile[260] = { 0 };
 		ZeroMemory(&ofn, sizeof(OPENFILENAME));
@@ -23,13 +23,15 @@ namespace Hazel
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
-		if (GetOpenFileNameA(&ofn) == TRUE) {
+		if (GetOpenFileNameA(&ofn) == TRUE) 
+		{
 			return ofn.lpstrFile;
 		}
 		return std::string();
 	}
 
-	std::string FileDialogs::SaveFile(const char* filter) {
+	std::string FileDialogs::SaveFile(const char* filter)
+	{
 		OPENFILENAMEA ofn;
 		CHAR szFile[260] = { 0 };
 		ZeroMemory(&ofn, sizeof(OPENFILENAME));
@@ -44,10 +46,11 @@ namespace Hazel
 		ofn.lpstrDefExt = strchr(filter, '\0') + 1;
 
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
-		if (GetSaveFileNameA(&ofn) == TRUE) {
+		if (GetSaveFileNameA(&ofn) == TRUE)
+		{
 			return ofn.lpstrFile;
 		}
 		return std::string();
 	}
-	
-} // namespace Hazel
+
+}


### PR DESCRIPTION
#### Added Default Extension
On saving files, if the extension is not specified, the file isn't saved with a `.hazel` extension, and hence doesn't turn up in the OpenFile Dialog.

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Set the default extension using `OPENFILENAMEA.lpstrDefExt` option.