### PR TITLE
Added .bat file for removing solution and build files

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -1,4 +1,5 @@
 include "./vendor/premake/premake_customization/solution_items.lua"
+include "./vendor/premake/premake_customization/clean_build.lua"
 include "Dependencies.lua"
 
 workspace "Hazel"

--- a/scripts/Win-CleanBuild.bat
+++ b/scripts/Win-CleanBuild.bat
@@ -1,8 +1,7 @@
 @echo off
 pushd %~dp0\..\
 RMDIR /S /Q .vs
-DEL *.sln 
-DEL /S /Q *.vcxproj *.vcxproj.filters *.vcxproj.user
+DEL /S /Q *.sln *.vcxproj *.vcxproj.filters *.vcxproj.user
 FOR /d /r . %%d IN ("bin") DO @IF EXIST "%%d" rd /s /q "%%d"
 FOR /d /r . %%d IN ("bin-int") DO @IF EXIST "%%d" rd /s /q "%%d"
 popd

--- a/scripts/Win-CleanBuild.bat
+++ b/scripts/Win-CleanBuild.bat
@@ -1,0 +1,9 @@
+@echo off
+pushd %~dp0\..\
+RMDIR /S /Q .vs
+DEL *.sln 
+DEL /S /Q *.vcxproj *.vcxproj.filters *.vcxproj.user
+FOR /d /r . %%d IN ("bin") DO @IF EXIST "%%d" rd /s /q "%%d"
+FOR /d /r . %%d IN ("bin-int") DO @IF EXIST "%%d" rd /s /q "%%d"
+popd
+PAUSE

--- a/scripts/Win-CleanBuild.bat
+++ b/scripts/Win-CleanBuild.bat
@@ -1,8 +1,7 @@
-@echo off
+
 pushd %~dp0\..\
-RMDIR /S /Q .vs
-DEL /S /Q *.sln *.vcxproj *.vcxproj.filters *.vcxproj.user
-FOR /d /r . %%d IN ("bin") DO @IF EXIST "%%d" rd /s /q "%%d"
-FOR /d /r . %%d IN ("bin-int") DO @IF EXIST "%%d" rd /s /q "%%d"
+rmdir /S /Q .vs
+del /S /Q *.sln *.vcxproj *.vcxproj.filters *.vcxproj.user
+call vendor\premake\bin\premake5.exe clean
 popd
 PAUSE

--- a/vendor/premake/premake_customization/clean_build.lua
+++ b/vendor/premake/premake_customization/clean_build.lua
@@ -1,0 +1,11 @@
+-- Clean Function
+newaction {
+	trigger     = "clean",
+	description = "clean build files",
+	execute     = function ()
+		print("clean the build...")
+		os.rmdir("./bin")
+		os.rmdir("./bin-int")
+		print("done.")
+	end
+}


### PR DESCRIPTION
#### Automatically delete VS solution files and build directories
In order to make a thorough rebuild, we have to go in each submodule or project folder, to find each visual studio solution file and any build directories.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix
I have added a batch file in the scripts folder which detects `bin` and `bin-int` directories recursively and deletes it. Also it detects the generated visual studio solution files and deletes it as well.

#### Additional Context
A workaround is needed to exclude the bin folder in the premake directory
