### PR TITLE
Set vec4 and vec2's encoding style to Flow + use yaml-cpp to load files

### DIFF
--- a/Hazel/src/Hazel/Scene/SceneSerializer.cpp
+++ b/Hazel/src/Hazel/Scene/SceneSerializer.cpp
@@ -19,6 +19,7 @@ namespace YAML {
 			node.push_back(rhs.x);
 			node.push_back(rhs.y);
 			node.push_back(rhs.z);
+			node.SetStyle(EmitterStyle::Flow);
 			return node;
 		}
 
@@ -44,6 +45,7 @@ namespace YAML {
 			node.push_back(rhs.y);
 			node.push_back(rhs.z);
 			node.push_back(rhs.w);
+			node.SetStyle(EmitterStyle::Flow);
 			return node;
 		}
 

--- a/Hazel/src/Hazel/Scene/SceneSerializer.cpp
+++ b/Hazel/src/Hazel/Scene/SceneSerializer.cpp
@@ -181,11 +181,7 @@ namespace Hazel {
 
 	bool SceneSerializer::Deserialize(const std::string& filepath)
 	{
-		std::ifstream stream(filepath);
-		std::stringstream strStream;
-		strStream << stream.rdbuf();
-
-		YAML::Node data = YAML::Load(strStream.str());
+		YAML::Node data = YAML::LoadFile(filepath);
 		if (!data["Scene"])
 			return false;
 


### PR DESCRIPTION
I made vec3 and vec4's emitter style to be Flow just like inside `operator <<` which we have  `out << YAML::Flow;`
I had this in my own game engine and I think its cool to be also in Hazel.
and use `YAML::LoadFile` to load files.