### PR TITLE
Warn if user tries to add a component if already present

### DIFF
--- a/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
@@ -221,23 +221,23 @@ namespace Hazel {
 
 		if (ImGui::BeginPopup("AddComponent"))
 		{
-			if (!m_SelectionContext.HasComponent<CameraComponent>())
-			{
 				if (ImGui::MenuItem("Camera"))
 				{
-					m_SelectionContext.AddComponent<CameraComponent>();
+					if (!m_SelectionContext.HasComponent<CameraComponent>())
+						m_SelectionContext.AddComponent<CameraComponent>();
+					else
+						HZ_CORE_WARN("This entity already has the Camera Component!");
 					ImGui::CloseCurrentPopup();
 				}
-			}
 
-			if (!m_SelectionContext.HasComponent<SpriteRendererComponent>())
-			{
 				if (ImGui::MenuItem("Sprite Renderer"))
 				{
-					m_SelectionContext.AddComponent<SpriteRendererComponent>();
+					if (!m_SelectionContext.HasComponent<SpriteRendererComponent>())
+						m_SelectionContext.AddComponent<SpriteRendererComponent>();
+					else
+						HZ_CORE_WARN("This entity already has the Sprite Renderer Component!");
 					ImGui::CloseCurrentPopup();
 				}
-			}
 
 			ImGui::EndPopup();
 		}

--- a/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
@@ -221,16 +221,22 @@ namespace Hazel {
 
 		if (ImGui::BeginPopup("AddComponent"))
 		{
-			if (ImGui::MenuItem("Camera"))
+			if (!m_SelectionContext.HasComponent<CameraComponent>())
 			{
-				m_SelectionContext.AddComponent<CameraComponent>();
-				ImGui::CloseCurrentPopup();
+				if (ImGui::MenuItem("Camera"))
+				{
+					m_SelectionContext.AddComponent<CameraComponent>();
+					ImGui::CloseCurrentPopup();
+				}
 			}
 
-			if (ImGui::MenuItem("Sprite Renderer"))
+			if (!m_SelectionContext.HasComponent<SpriteRendererComponent>())
 			{
-				m_SelectionContext.AddComponent<SpriteRendererComponent>();
-				ImGui::CloseCurrentPopup();
+				if (ImGui::MenuItem("Sprite Renderer"))
+				{
+					m_SelectionContext.AddComponent<SpriteRendererComponent>();
+					ImGui::CloseCurrentPopup();
+				}
 			}
 
 			ImGui::EndPopup();


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The Add Component menu retains the Camera and Sprite Renderer component even if they are already present. If one clicks on them, then the program crashes.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
The menu item does not appear if the component is already there.
