### PR TITLE
Added loging glm vectors, matrix and quaternios

### DIFF
--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -42,8 +42,7 @@ inline OStream& operator<<(OStream& os, const glm::mat<C, R, T, Q>& matrix)
 template<typename OStream, typename T, glm::qualifier Q>
 inline OStream& operator<<(OStream& os, glm::qua<T, Q> quaternio)
 {
-	os << glm::to_string(quaternio);
-	return os;
+	return os << glm::to_string(quaternio);
 }
 
 // Core log macros

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -1,5 +1,7 @@
 #pragma once
 
+include "glm/gtx/string_cast.hpp"
+
 #include "Hazel/Core/Base.h"
 
 // This ignores all warnings raised inside External headers

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -1,6 +1,6 @@
 #pragma once
 
-include "glm/gtx/string_cast.hpp"
+#include "glm/gtx/string_cast.hpp"
 
 #include "Hazel/Core/Base.h"
 

--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -25,6 +25,25 @@ namespace Hazel {
 
 }
 
+template<typename OStream, glm::length_t L, typename T, glm::qualifier Q>
+inline OStream& operator<<(OStream& os, const glm::vec<L, T, Q>& vector)
+{
+	return os << glm::to_string(vector);
+}
+
+template<typename OStream, glm::length_t C, glm::length_t R, typename T, glm::qualifier Q>
+inline OStream& operator<<(OStream& os, const glm::mat<C, R, T, Q>& matrix)
+{
+	return os << glm::to_string(matrix);
+}
+
+template<typename OStream, typename T, glm::qualifier Q>
+inline OStream& operator<<(OStream& os, glm::qua<T, Q> quaternio)
+{
+	os << glm::to_string(quaternio);
+	return os;
+}
+
 // Core log macros
 #define HZ_CORE_TRACE(...)    ::Hazel::Log::GetCoreLogger()->trace(__VA_ARGS__)
 #define HZ_CORE_INFO(...)     ::Hazel::Log::GetCoreLogger()->info(__VA_ARGS__)


### PR DESCRIPTION
#### The issue
If you want log a glm vector, matrix or quaternio, you must type HAZEL_INFO(glm::to_string(some_vector)) and that glm::to_string is very annoying. So, now you can type HAZEL_INFO(some_vector) with out that glm::to_string.

#### PR impact

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
No more glm::to_string to log a glm vector.
