### PR TITLE
Fixed Z-Fighting bug in Texture Shader and updated GLSL version

### DIFF
--- a/Hazelnut/assets/shaders/Texture.glsl
+++ b/Hazelnut/assets/shaders/Texture.glsl
@@ -1,7 +1,7 @@
 // Basic Texture Shader
 
 #type vertex
-#version 330 core
+#version 450
 
 layout(location = 0) in vec3 a_Position;
 layout(location = 1) in vec4 a_Color;
@@ -13,7 +13,7 @@ uniform mat4 u_ViewProjection;
 
 out vec4 v_Color;
 out vec2 v_TexCoord;
-out float v_TexIndex;
+out flat float v_TexIndex;
 out float v_TilingFactor;
 
 void main()
@@ -26,13 +26,13 @@ void main()
 }
 
 #type fragment
-#version 330 core
+#version 450
 
 layout(location = 0) out vec4 color;
 
 in vec4 v_Color;
 in vec2 v_TexCoord;
-in float v_TexIndex;
+in flat float v_TexIndex;
 in float v_TilingFactor;
 
 uniform sampler2D u_Textures[32];

--- a/Sandbox/assets/shaders/Texture.glsl
+++ b/Sandbox/assets/shaders/Texture.glsl
@@ -1,7 +1,7 @@
 // Basic Texture Shader
 
 #type vertex
-#version 330 core
+#version 450
 
 layout(location = 0) in vec3 a_Position;
 layout(location = 1) in vec4 a_Color;
@@ -13,7 +13,7 @@ uniform mat4 u_ViewProjection;
 
 out vec4 v_Color;
 out vec2 v_TexCoord;
-out float v_TexIndex;
+out flat float v_TexIndex;
 out float v_TilingFactor;
 
 void main()
@@ -26,13 +26,13 @@ void main()
 }
 
 #type fragment
-#version 330 core
+#version 450
 
 layout(location = 0) out vec4 color;
 
 in vec4 v_Color;
 in vec2 v_TexCoord;
-in float v_TexIndex;
+in flat float v_TexIndex;
 in float v_TilingFactor;
 
 uniform sampler2D u_Textures[32];


### PR DESCRIPTION
Without this change, going 3D with a perspective camera will affect how the textures are rendered. If you don't make v_TexIndex flat, the texture will glitch out when changing the yaw of the camera. Making it flat will solve this issue. I also updated the GLSL version so that it's compatible with flat.

Edit : 
Another way to fix this issue would be to make the TexIndex attrib an integer, and instead of having glVertexAttribPointer, we would have glVertexAttribIPointer.