### PR TITLE
Change to FileDialogs' methods so that they return std::optional.

### DIFF
--- a/Hazel/src/Hazel/Utils/PlatformUtils.h
+++ b/Hazel/src/Hazel/Utils/PlatformUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <optional>
 
 namespace Hazel {
 
@@ -8,8 +9,8 @@ namespace Hazel {
 	{
 	public:
 		// These return empty strings if cancelled
-		static std::string OpenFile(const char* filter);
-		static std::string SaveFile(const char* filter);
+		static std::optional<std::string> OpenFile(const char* filter);
+		static std::optional<std::string> SaveFile(const char* filter);
 	};
 
 }

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -40,7 +40,7 @@ namespace Hazel {
 		ofn.nMaxFile = sizeof(szFile);
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
-    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
+		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
 
 		// Sets the default extension by extracting it from the filter
 		ofn.lpstrDefExt = strchr(filter, '\0') + 1;

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -10,7 +10,7 @@
 
 namespace Hazel {
 
-	std::string FileDialogs::OpenFile(const char* filter)
+	std::optional<std::string> FileDialogs::OpenFile(const char* filter)
 	{
 		OPENFILENAMEA ofn;
 		CHAR szFile[260] = { 0 };
@@ -26,10 +26,10 @@ namespace Hazel {
 		{
 			return ofn.lpstrFile;
 		}
-		return std::string();
+		return std::nullopt;
 	}
 
-	std::string FileDialogs::SaveFile(const char* filter)
+	std::optional<std::string> FileDialogs::SaveFile(const char* filter)
 	{
 		OPENFILENAMEA ofn;
 		CHAR szFile[260] = { 0 };
@@ -45,7 +45,7 @@ namespace Hazel {
 		{
 			return ofn.lpstrFile;
 		}
-		return std::string();
+		return std::nullopt;
 	}
 
 }

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -277,25 +277,25 @@ namespace Hazel {
 
 	void EditorLayer::OpenScene()
 	{
-		std::string filepath = FileDialogs::OpenFile("Hazel Scene (*.hazel)\0*.hazel\0");
-		if (!filepath.empty())
+		std::optional<std::string> filepath = FileDialogs::OpenFile("Hazel Scene (*.hazel)\0*.hazel\0");
+		if (filepath)
 		{
 			m_ActiveScene = CreateRef<Scene>();
 			m_ActiveScene->OnViewportResize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
 			m_SceneHierarchyPanel.SetContext(m_ActiveScene);
 
 			SceneSerializer serializer(m_ActiveScene);
-			serializer.Deserialize(filepath);
+			serializer.Deserialize(*filepath);
 		}
 	}
 
 	void EditorLayer::SaveSceneAs()
 	{
-		std::string filepath = FileDialogs::SaveFile("Hazel Scene (*.hazel)\0*.hazel\0");
-		if (!filepath.empty())
+		std::optional<std::string> filepath = FileDialogs::SaveFile("Hazel Scene (*.hazel)\0*.hazel\0");
+		if (filepath)
 		{
 			SceneSerializer serializer(m_ActiveScene);
-			serializer.Serialize(filepath);
+			serializer.Serialize(*filepath);
 		}
 	}
 


### PR DESCRIPTION
Not a major change, just personally think we should be using `std::optional` in this instance instead of returning and checking for an empty string.

#### PR impact
 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

Not sure any additional context is needed here!