### PR TITLE
Added .hazel extension to files saved when no extension has been provided.

### DIFF
--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -41,6 +41,7 @@ namespace Hazel {
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
+		ofn.lpstrDefExt = "hazel";
 		if (GetSaveFileNameA(&ofn) == TRUE)
 		{
 			return ofn.lpstrFile;


### PR DESCRIPTION
When saving a scene, the dialogue menu says "Save as type" (_.hazel_)
However this is untrue and will save as a generic file-type and is therefore un-findable in the "Open" dialogue.

![image](https://user-images.githubusercontent.com/47081415/97737700-4735da80-1ad5-11eb-89c3-2743219eea1b.png)

This change will make files that have no provided extension to be defaulted to **.hazel**.

#### PR impact

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Additional context

(from master branch)
Above is the "Open" dialogue
Below is Windows Explorer
![image](https://user-images.githubusercontent.com/47081415/97738010-aeec2580-1ad5-11eb-848f-c7d114c88112.png)

