### PR TITLE
Added a TryCatch to YAML::LoadFile

### DIFF
--- a/Hazel/src/Hazel/Scene/SceneSerializer.cpp
+++ b/Hazel/src/Hazel/Scene/SceneSerializer.cpp
@@ -182,10 +182,15 @@ namespace Hazel {
 	bool SceneSerializer::Deserialize(const std::string& filepath)
 	{
 		YAML::Node data;
-		try { data = YAML::LoadFile(filepath); }
+		try
+		{
+			data = YAML::LoadFile(filepath);
+		}
 		catch (const YAML::ParserException& ex)
-		{ HZ_CORE_ERROR("Failed to load .hazel file '{0}'\n     {1}", filepath, ex.what()); }
-
+		{
+			HZ_CORE_ERROR("Failed to deserialize scene '{0}'\n     {1}", filepath, ex.what());
+			return false;
+		}
 		if (!data["Scene"])
 			return false;
 

--- a/Hazel/src/Hazel/Scene/SceneSerializer.cpp
+++ b/Hazel/src/Hazel/Scene/SceneSerializer.cpp
@@ -181,7 +181,11 @@ namespace Hazel {
 
 	bool SceneSerializer::Deserialize(const std::string& filepath)
 	{
-		YAML::Node data = YAML::LoadFile(filepath);
+		YAML::Node data;
+		try { data = YAML::LoadFile(filepath); }
+		catch (const YAML::ParserException& ex)
+		{ HZ_CORE_ERROR("Failed to load .hazel file '{0}'\n     {1}", filepath, ex.what()); }
+
 		if (!data["Scene"])
 			return false;
 


### PR DESCRIPTION
#### Issue
If you try to load a corrupt/non-YAML file, the engine will hard crash on you. This is because the function throws an exception of it was unable to load the objects, and that exception is never caught.

#### PR impact 

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix 
adding a simple try catch statement to the function with an error on the catch will fix the problem.
While you could also return false on the catch, it's not needed as data will be unset and the next if-statement will return false, breaking the function anyway.