### PR TITLE
Caching Transformation Matrix in TransformComponent

### DIFF
--- a/Hazel/src/Hazel/Scene/Components.h
+++ b/Hazel/src/Hazel/Scene/Components.h
@@ -29,16 +29,42 @@ namespace Hazel {
 		TransformComponent(const glm::vec3& translation)
 			: Translation(translation) {}
 
-		glm::mat4 GetTransform() const
+		glm::mat4 GetTransform()
 		{
-			glm::mat4 rotation = glm::rotate(glm::mat4(1.0f), Rotation.x, { 1, 0, 0 })
-				* glm::rotate(glm::mat4(1.0f), Rotation.y, { 0, 1, 0 })
-				* glm::rotate(glm::mat4(1.0f), Rotation.z, { 0, 0, 1 });
+			bool isDirty = false;
+			if (Translation.x != m_TransformationMatrix[3].x
+				|| Translation.y != m_TransformationMatrix[3].y
+				|| Translation.z != m_TransformationMatrix[3].z)
+			{
+				isDirty = true;
+			}
+			if (Rotation != m_PreviousRotation)
+			{
+				isDirty = true;
+				m_PreviousRotation = Rotation;
+			}
+			if (Scale != m_PreviousScale)
+			{
+				isDirty = true;
+				m_PreviousScale = Scale;
+			}
 
-			return glm::translate(glm::mat4(1.0f), Translation)
-				* rotation
-				* glm::scale(glm::mat4(1.0f), Scale);
+			if (isDirty)
+			{
+				//HZ_CORE_DEBUG("Transformation component changes detected. Recalculating Transformation Matrix...");
+				m_TransformationMatrix = glm::translate(glm::mat4(1.0f), Translation)
+					* glm::rotate(glm::mat4(1.0f), Rotation.x, { 1, 0, 0 })
+					* glm::rotate(glm::mat4(1.0f), Rotation.y, { 0, 1, 0 })
+					* glm::rotate(glm::mat4(1.0f), Rotation.z, { 0, 0, 1 })
+					* glm::scale(glm::mat4(1.0f), Scale);
+			}
+
+			return m_TransformationMatrix;
 		}
+	private:
+		glm::vec3 m_PreviousRotation = { 0.0f, 0.0f, 0.0f };
+		glm::vec3 m_PreviousScale = { 0.0f, 0.0f, 0.0f };
+		glm::mat4 m_TransformationMatrix;
 	};
 
 	struct SpriteRendererComponent

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -27,6 +27,20 @@ namespace Hazel {
 		m_Framebuffer = Framebuffer::Create(fbSpec);
 
 		m_ActiveScene = CreateRef<Scene>();
+		m_CameraEntity = m_ActiveScene->CreateEntity("Camera A");
+		m_CameraEntity.AddComponent<CameraComponent>();
+
+
+		for (int i = 0; i < 20000; ++i)
+		{
+			auto& entity = m_ActiveScene->CreateEntity("Entity");
+			entity.AddComponent<SpriteRendererComponent>(glm::vec4(1.0f, 1.0f, 0.0f, 1.0f));
+
+			//auto& transform = entity.GetComponent<TransformComponent>();
+			//transform.Translation = glm::vec3(
+			//	rand
+			//);
+		}
 
 #if 0
 		// Entity


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
This PR doesn't fix any issue.
This PR update `TransformationComponent` for (hopefully) better performance.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
- `TransformComponent` now caches Transformation matrix and only reconstructs it when Translation, Rotation or Scale is changed.
- Transformation matrix reconstruction only take places when it is requested (when `GetTransform()` is called).

#### Additional context
- The cost for a better performance is `TransformerComponent` now takes up more memory for caching values (+88 bytes).
