### PR TITLE
Make Open and Save file dialogs start from current working directory

### DIFF
--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -15,11 +15,16 @@ namespace Hazel {
 	{
 		OPENFILENAMEA ofn;
 		CHAR szFile[260] = { 0 };
+		CHAR currentDir[256] = { 0 };
 		ZeroMemory(&ofn, sizeof(OPENFILENAME));
 		ofn.lStructSize = sizeof(OPENFILENAME);
 		ofn.hwndOwner = glfwGetWin32Window((GLFWwindow*)Application::Get().GetWindow().GetNativeWindow());
 		ofn.lpstrFile = szFile;
 		ofn.nMaxFile = sizeof(szFile);
+		if (GetCurrentDirectoryA(256, currentDir))
+		{
+			ofn.lpstrInitialDir = currentDir;
+		}
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
@@ -33,14 +38,19 @@ namespace Hazel {
 	{
 		OPENFILENAMEA ofn;
 		CHAR szFile[260] = { 0 };
+		CHAR currentDir[256] = { 0 };
 		ZeroMemory(&ofn, sizeof(OPENFILENAME));
 		ofn.lStructSize = sizeof(OPENFILENAME);
 		ofn.hwndOwner = glfwGetWin32Window((GLFWwindow*)Application::Get().GetWindow().GetNativeWindow());
 		ofn.lpstrFile = szFile;
 		ofn.nMaxFile = sizeof(szFile);
+		if (GetCurrentDirectoryA(256, currentDir))
+		{
+			ofn.lpstrInitialDir = currentDir;
+		}
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
-		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
+		ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_NOCHANGEDIR;
 
 		// Sets the default extension by extracting it from the filter
 		ofn.lpstrDefExt = strchr(filter, '\0') + 1;

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -22,9 +22,7 @@ namespace Hazel {
 		ofn.lpstrFile = szFile;
 		ofn.nMaxFile = sizeof(szFile);
 		if (GetCurrentDirectoryA(256, currentDir))
-		{
 			ofn.lpstrInitialDir = currentDir;
-		}
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
@@ -45,9 +43,7 @@ namespace Hazel {
 		ofn.lpstrFile = szFile;
 		ofn.nMaxFile = sizeof(szFile);
 		if (GetCurrentDirectoryA(256, currentDir))
-		{
 			ofn.lpstrInitialDir = currentDir;
-		}
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_NOCHANGEDIR;


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
This PR doesn't fix any issue.
This PR update `FileDialogs` for better QoL: now Open File and Save File dialogs will start from current working directory (which is the Hazelnut or Sandbox project directory. You don't have to browse your whole computer to go to the `assets/scenes` folder anymore.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
- Calls `GetCurrentDirectoryA()` to get the current directory and set it to `lpInitialDir` in `OpenFile()` and `SaveFile()`.

#### Additional context
- Should works on Windows platform only 😄
