### PR TITLE
Changed std::unique_ptr to Scope in Application.h

### DIFF
--- a/Hazel/src/Hazel/Core/Application.h
+++ b/Hazel/src/Hazel/Core/Application.h
@@ -38,7 +38,7 @@ namespace Hazel {
 		bool OnWindowClose(WindowCloseEvent& e);
 		bool OnWindowResize(WindowResizeEvent& e);
 	private:
-		std::unique_ptr<Window> m_Window;
+		Scope<Window> m_Window;
 		ImGuiLayer* m_ImGuiLayer;
 		bool m_Running = true;
 		bool m_Minimized = false;


### PR DESCRIPTION
The `std::unique_ptr` is changed to `Scope`. Nothing to explain more :)
