### PR TITLE
Fixed unexpected behaviour in OpenGLVertexArray when using int attributes

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -72,6 +72,17 @@ namespace Hazel {
 				case ShaderDataType::Float2:
 				case ShaderDataType::Float3:
 				case ShaderDataType::Float4:
+				{
+					glEnableVertexAttribArray(m_VertexBufferIndex);
+					glVertexAttribPointer(m_VertexBufferIndex,
+						element.GetComponentCount(),
+						ShaderDataTypeToOpenGLBaseType(element.Type),
+						element.Normalized ? GL_TRUE : GL_FALSE,
+						layout.GetStride(),
+						(const void*)element.Offset);
+					m_VertexBufferIndex++;
+					break;
+				}
 				case ShaderDataType::Int:
 				case ShaderDataType::Int2:
 				case ShaderDataType::Int3:
@@ -79,10 +90,9 @@ namespace Hazel {
 				case ShaderDataType::Bool:
 				{
 					glEnableVertexAttribArray(m_VertexBufferIndex);
-					glVertexAttribPointer(m_VertexBufferIndex,
+					glVertexAttribIPointer(m_VertexBufferIndex,
 						element.GetComponentCount(),
 						ShaderDataTypeToOpenGLBaseType(element.Type),
-						element.Normalized ? GL_TRUE : GL_FALSE,
 						layout.GetStride(),
 						(const void*)element.Offset);
 					m_VertexBufferIndex++;


### PR DESCRIPTION
glVertexAttribPointer will auto cast any int types to float between setting the buffer data and data being passed into the shader program. Even when the shader layout states the attribute is an int, the value passed has already been cast to a float, and it is then reinterpreted as an int, ie. the shader program literally sees the float exponent and mantissa bits set. This fix assumes that any Hazel users would expect to receive the same bit-wise int value if they pushed an int into the buffer and set the layout attribute to have an int type in a shader. The issue is subtle for opengl newcommers and likely to cause a lot of confusion if not patched

Impact is minimal, no code in the repo makes use of DataType::Int. Can't comment on any projects that take Hazel as a dependency, but given it does not work in the current state the new code introduced is unlikely to be hit at the moment

No issue currently opened for this fix

Fix adds splits the floating point and integer cases in the switch statement where the vertex array attribute pointers are set

This fix was derrived from the following form post and opengl documentation:
[https://community.amd.com/t5/opengl-vulkan/integer-vertex-specification-is-cast-from-glint-to-glfloat/td-p/231010]
[https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml]

