### PR TITLE
Fixed Math Function Declaration

### DIFF
--- a/Hazel/src/Hazel/Math/Math.h
+++ b/Hazel/src/Hazel/Math/Math.h
@@ -3,5 +3,7 @@
 #include <glm/glm.hpp>
 
 namespace Hazel::Math {
+
 	bool DecomposeTransform(const glm::mat4& transform, glm::vec3& translation, glm::vec3& rotation, glm::vec3& scale);
+
 }

--- a/Hazel/src/Hazel/Math/Math.h
+++ b/Hazel/src/Hazel/Math/Math.h
@@ -3,7 +3,5 @@
 #include <glm/glm.hpp>
 
 namespace Hazel::Math {
-
-	bool DecomposeTransform(const glm::mat4& transform, glm::vec3& outTranslation, glm::vec3& outRotation, glm::vec3& outScale);
-
+	bool DecomposeTransform(const glm::mat4& transform, glm::vec3& translation, glm::vec3& rotation, glm::vec3& scale);
 }


### PR DESCRIPTION
#### Fixed function declaration of DecomposeTransform() function
When @TheCherno copied the DecomposeTransform() function diff, the declaration he created in Math.h class was different from the definition, which could lead to some inconsistencies

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Changed the declaration variable names to the ones which were copied in diff