### PR TITLE
Removed redundant include in WindowsPlatformUtils.cpp file

### DIFF
--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -9,6 +9,7 @@
 #include "Hazel/Core/Application.h"
 
 namespace Hazel {
+
 	std::optional<std::string> FileDialogs::OpenFile(const char* filter)
 	{
 		OPENFILENAMEA ofn;
@@ -53,4 +54,5 @@ namespace Hazel {
 			return ofn.lpstrFile;
 		return std::nullopt;
 	}
+
 }

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -1,7 +1,6 @@
 #include "hzpch.h"
 #include "Hazel/Utils/PlatformUtils.h"
 
-#include <sstream>
 #include <commdlg.h>
 #include <GLFW/glfw3.h>
 #define GLFW_EXPOSE_NATIVE_WIN32
@@ -10,7 +9,6 @@
 #include "Hazel/Core/Application.h"
 
 namespace Hazel {
-
 	std::optional<std::string> FileDialogs::OpenFile(const char* filter)
 	{
 		OPENFILENAMEA ofn;
@@ -23,8 +21,8 @@ namespace Hazel {
 		ofn.lpstrFilter = filter;
 		ofn.nFilterIndex = 1;
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
-    
-		if (GetOpenFileNameA(&ofn) == TRUE) 
+
+		if (GetOpenFileNameA(&ofn) == TRUE)
 			return ofn.lpstrFile;
 		return std::nullopt;
 	}
@@ -49,5 +47,4 @@ namespace Hazel {
 			return ofn.lpstrFile;
 		return std::nullopt;
 	}
-
 }


### PR DESCRIPTION
#### Redundant include in WindowsPlatformUtils.cpp file
In pull request [355](https://github.com/TheCherno/Hazel/pull/355#issue-509596608), over the course of discussion with other developers and implementation of the mechanism, I forgot to remove the `sstream` header file.

#### PR impact 
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Removed the redundant header file.
