### PR TITLE
Application will now use Nvidia card if available

### DIFF
--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -11,8 +11,10 @@ extern "C" {
 	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
 }
 
-int main(int argc, char** argv) {
-=======
+extern "C" {
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
+
 int main(int argc, char** argv)
 {
 >>>>>>> 9ee977d... Updated as per @lovely_santa 's suggestion

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -16,7 +16,7 @@ extern "C" {
 }
 
 extern "C" {
-	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
 }
 
 int main(int argc, char** argv)

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -15,6 +15,10 @@ extern "C" {
 	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
 }
 
+extern "C" {
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
+
 int main(int argc, char** argv)
 {
 >>>>>>> 9ee977d... Updated as per @lovely_santa 's suggestion

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -6,18 +6,8 @@
 
 extern Hazel::Application* Hazel::CreateApplication(ApplicationCommandLineArgs args);
 
-<<<<<<< HEAD
-extern "C" {
-	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
-}
-
-extern "C" {
-	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
-}
-
 int main(int argc, char** argv)
 {
->>>>>>> 9ee977d... Updated as per @lovely_santa 's suggestion
 	Hazel::Log::Init();
 
 	HZ_PROFILE_BEGIN_SESSION("Startup", "HazelProfile-Startup.json");

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -10,8 +10,7 @@ extern "C" {
 	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
 }
 
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
 	Hazel::Log::Init();
 
 	HZ_PROFILE_BEGIN_SESSION("Startup", "HazelProfile-Startup.json");

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -15,10 +15,6 @@ extern "C" {
 	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
 }
 
-extern "C" {
-	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
-}
-
 int main(int argc, char** argv)
 {
 >>>>>>> 9ee977d... Updated as per @lovely_santa 's suggestion

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -6,6 +6,10 @@
 
 extern Hazel::Application* Hazel::CreateApplication(ApplicationCommandLineArgs args);
 
+extern "C" {
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
+
 int main(int argc, char** argv)
 {
 	Hazel::Log::Init();

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -7,7 +7,7 @@
 extern Hazel::Application* Hazel::CreateApplication(ApplicationCommandLineArgs args);
 
 extern "C" {
-	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
 }
 
 int main(int argc, char** argv)

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -6,11 +6,16 @@
 
 extern Hazel::Application* Hazel::CreateApplication(ApplicationCommandLineArgs args);
 
+<<<<<<< HEAD
 extern "C" {
 	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
 }
 
 int main(int argc, char** argv) {
+=======
+int main(int argc, char** argv)
+{
+>>>>>>> 9ee977d... Updated as per @lovely_santa 's suggestion
 	Hazel::Log::Init();
 
 	HZ_PROFILE_BEGIN_SESSION("Startup", "HazelProfile-Startup.json");

--- a/Hazel/src/Hazel/Core/EntryPoint.h
+++ b/Hazel/src/Hazel/Core/EntryPoint.h
@@ -12,7 +12,7 @@ extern "C" {
 }
 
 extern "C" {
-	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
 }
 
 int main(int argc, char** argv)

--- a/Hazelnut/src/HazelnutApp.cpp
+++ b/Hazelnut/src/HazelnutApp.cpp
@@ -7,6 +7,7 @@ namespace Hazel {
 	#ifdef HZ_PLATFORM_WINDOWS
 	extern "C" {
 		__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
+		__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 	}
 	#endif
 

--- a/Hazelnut/src/HazelnutApp.cpp
+++ b/Hazelnut/src/HazelnutApp.cpp
@@ -4,6 +4,11 @@
 #include "EditorLayer.h"
 
 namespace Hazel {
+	#ifdef HZ_PLATFORM_WINDOWS
+	extern "C" {
+		__declspec(dllexport) uint32_t NvOptimusEnablement = 0x00000001;
+	}
+	#endif
 
 	class Hazelnut : public Application
 	{


### PR DESCRIPTION
#### Application uses integrated graphics by default
Even if an Nvidia card is available, the application uses integrated graphics solution like Intel UHD graphics. We need to change the settings in Nvidia Control Panel for that particular application.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
In this [post](https://www.reddit.com/r/gamedev/comments/bk7xbe/psa_for_anyone_developing_a_gameengine_in_c/) mentioned on Cherno's Discord Server, a solution is stated regarding this problem. The highlighted code block in that post is added to `HazelnutApp.cpp`. This enables the application to launch with the high-performance GPU instead of the integrated one.

#### Additional context
As stated in the above mentioned post, this solution works only for Windows. Also, I have tested it on my fork, and it works, but it may need some additional testing on other machines. 

Reference link : https://www.reddit.com/r/gamedev/comments/bk7xbe/psa_for_anyone_developing_a_gameengine_in_c/
