### PR TITLE
Fixed ImGuizmo Bug and made changes for convenience

### DIFF
--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
@@ -50,7 +50,7 @@ namespace Hazel {
 			style.Colors[ImGuiCol_WindowBg].w = 1.0f;
 		}
 
-		SetDarkThemeColors();
+		SetDarkThemeColors("Monocrom");
 
 		Application& app = Application::Get();
 		GLFWwindow* window = static_cast<GLFWwindow*>(app.GetWindow().GetNativeWindow());
@@ -110,37 +110,113 @@ namespace Hazel {
 		}
 	}
 
-	void ImGuiLayer::SetDarkThemeColors()
+	void ImGuiLayer::SetDarkThemeColors(std::string theme)
 	{
-		auto& colors = ImGui::GetStyle().Colors;
-		colors[ImGuiCol_WindowBg] = ImVec4{ 0.1f, 0.105f, 0.11f, 1.0f };
-
-		// Headers
-		colors[ImGuiCol_Header] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
-		colors[ImGuiCol_HeaderHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
-		colors[ImGuiCol_HeaderActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
 		
-		// Buttons
-		colors[ImGuiCol_Button] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
-		colors[ImGuiCol_ButtonHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
-		colors[ImGuiCol_ButtonActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+		auto& colors = ImGui::GetStyle().Colors;
+		if (theme == "DarkBlue")
+		{
+			ImGui::GetStyle().FrameRounding = 4.0f;
+			ImGui::GetStyle().GrabRounding = 4.0f;
+			// Headers
+			colors[ImGuiCol_Header] = ImVec4(0.20f, 0.25f, 0.29f, 0.55f);
+			colors[ImGuiCol_HeaderHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.80f);
+			colors[ImGuiCol_HeaderActive] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
 
-		// Frame BG
-		colors[ImGuiCol_FrameBg] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
-		colors[ImGuiCol_FrameBgHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
-		colors[ImGuiCol_FrameBgActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+			// Buttons
+			colors[ImGuiCol_Button] = ImVec4(0.20f, 0.25f, 0.29f, 1.00f);
+			colors[ImGuiCol_ButtonHovered] = ImVec4(0.28f, 0.56f, 1.00f, 1.00f);
+			colors[ImGuiCol_ButtonActive] = ImVec4(0.06f, 0.53f, 0.98f, 1.00f);
 
-		// Tabs
-		colors[ImGuiCol_Tab] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
-		colors[ImGuiCol_TabHovered] = ImVec4{ 0.38f, 0.3805f, 0.381f, 1.0f };
-		colors[ImGuiCol_TabActive] = ImVec4{ 0.28f, 0.2805f, 0.281f, 1.0f };
-		colors[ImGuiCol_TabUnfocused] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
-		colors[ImGuiCol_TabUnfocusedActive] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
+			// Frame BG
+			colors[ImGuiCol_FrameBg] = ImVec4(0.20f, 0.25f, 0.29f, 1.00f);
+			colors[ImGuiCol_FrameBgHovered] = ImVec4(0.12f, 0.20f, 0.28f, 1.00f);
+			colors[ImGuiCol_FrameBgActive] = ImVec4(0.09f, 0.12f, 0.14f, 1.00f);
 
-		// Title
-		colors[ImGuiCol_TitleBg] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
-		colors[ImGuiCol_TitleBgActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
-		colors[ImGuiCol_TitleBgCollapsed] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+			// Tabs
+			colors[ImGuiCol_Tab] = ImVec4(0.11f, 0.15f, 0.17f, 1.00f);
+			colors[ImGuiCol_TabHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.80f);
+			colors[ImGuiCol_TabActive] = ImVec4(0.20f, 0.25f, 0.29f, 1.00f);
+			colors[ImGuiCol_TabUnfocused] = ImVec4(0.11f, 0.15f, 0.17f, 1.00f);
+			colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.11f, 0.15f, 0.17f, 1.00f);
+
+			// Title
+			colors[ImGuiCol_TitleBg] = ImVec4(0.09f, 0.12f, 0.14f, 0.65f);
+			colors[ImGuiCol_TitleBgActive] = ImVec4(0.08f, 0.10f, 0.12f, 1.00f);
+			colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.00f, 0.00f, 0.00f, 0.51f);
+
+			colors[ImGuiCol_Text] = ImVec4(0.95f, 0.96f, 0.98f, 1.00f);
+			colors[ImGuiCol_TextDisabled] = ImVec4(0.36f, 0.42f, 0.47f, 1.00f);
+
+			colors[ImGuiCol_WindowBg] = ImVec4(0.11f, 0.15f, 0.17f, 1.00f);
+			colors[ImGuiCol_ChildBg] = ImVec4(0.15f, 0.18f, 0.22f, 1.00f);
+			colors[ImGuiCol_PopupBg] = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
+
+			colors[ImGuiCol_Border] = ImVec4(0.08f, 0.10f, 0.12f, 1.00f);
+			colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+
+			colors[ImGuiCol_MenuBarBg] = ImVec4(0.15f, 0.18f, 0.22f, 1.00f);
+
+			colors[ImGuiCol_ScrollbarBg] = ImVec4(0.02f, 0.02f, 0.02f, 0.39f);
+			colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.20f, 0.25f, 0.29f, 1.00f);
+			colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.18f, 0.22f, 0.25f, 1.00f);
+			colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.09f, 0.21f, 0.31f, 1.00f);
+
+			colors[ImGuiCol_CheckMark] = ImVec4(0.28f, 0.56f, 1.00f, 1.00f);
+
+			colors[ImGuiCol_SliderGrab] = ImVec4(0.28f, 0.56f, 1.00f, 1.00f);
+			colors[ImGuiCol_SliderGrabActive] = ImVec4(0.37f, 0.61f, 1.00f, 1.00f);
+
+			colors[ImGuiCol_Separator] = ImVec4(0.20f, 0.25f, 0.29f, 1.00f);
+			colors[ImGuiCol_SeparatorHovered] = ImVec4(0.10f, 0.40f, 0.75f, 0.78f);
+			colors[ImGuiCol_SeparatorActive] = ImVec4(0.10f, 0.40f, 0.75f, 1.00f);
+			colors[ImGuiCol_ResizeGrip] = ImVec4(0.26f, 0.59f, 0.98f, 0.25f);
+			colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
+			colors[ImGuiCol_ResizeGripActive] = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+
+			colors[ImGuiCol_PlotLines] = ImVec4(0.61f, 0.61f, 0.61f, 1.00f);
+			colors[ImGuiCol_PlotLinesHovered] = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
+			colors[ImGuiCol_PlotHistogram] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+			colors[ImGuiCol_PlotHistogramHovered] = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+			colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+			colors[ImGuiCol_DragDropTarget] = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
+			colors[ImGuiCol_NavHighlight] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+			colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
+			colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
+			colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
+		}
+		else if (theme == "Monocrom")
+		{
+			
+			colors[ImGuiCol_WindowBg] = ImVec4{ 0.1f, 0.105f, 0.11f, 1.0f };
+
+			// Headers
+			colors[ImGuiCol_Header] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
+			colors[ImGuiCol_HeaderHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
+			colors[ImGuiCol_HeaderActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+
+			// Buttons
+			colors[ImGuiCol_Button] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
+			colors[ImGuiCol_ButtonHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
+			colors[ImGuiCol_ButtonActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+
+			// Frame BG
+			colors[ImGuiCol_FrameBg] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
+			colors[ImGuiCol_FrameBgHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
+			colors[ImGuiCol_FrameBgActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+
+			// Tabs
+			colors[ImGuiCol_Tab] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+			colors[ImGuiCol_TabHovered] = ImVec4{ 0.38f, 0.3805f, 0.381f, 1.0f };
+			colors[ImGuiCol_TabActive] = ImVec4{ 0.28f, 0.2805f, 0.281f, 1.0f };
+			colors[ImGuiCol_TabUnfocused] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+			colors[ImGuiCol_TabUnfocusedActive] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
+
+			// Title
+			colors[ImGuiCol_TitleBg] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+			colors[ImGuiCol_TitleBgActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
+			colors[ImGuiCol_TitleBgCollapsed] = ImVec4{ 0.95f, 0.1505f, 0.951f, 1.0f };
+		}
 	}
 
 }

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.h
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.h
@@ -23,7 +23,7 @@ namespace Hazel {
 
 		void BlockEvents(bool block) { m_BlockEvents = block; }
 		
-		void SetDarkThemeColors();
+		void SetDarkThemeColors(std::string theme);
 	private:
 		bool m_BlockEvents = true;
 		float m_Time = 0.0f;

--- a/Hazelnut/imgui.ini
+++ b/Hazelnut/imgui.ini
@@ -1,10 +1,10 @@
 [Window][DockSpace Demo]
 Pos=0,0
-Size=2560,1387
+Size=1920,1013
 Collapsed=0
 
 [Window][Debug##Default]
-ViewportPos=1180,1184
+ViewportPos=1180,1023
 ViewportId=0x9F5F46A1
 Size=400,400
 Collapsed=0
@@ -16,14 +16,14 @@ Collapsed=0
 DockId=0x00000004,0
 
 [Window][Viewport]
-Pos=595,24
-Size=1590,1363
+Pos=372,24
+Size=1266,989
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][Scene Hierarchy]
 Pos=0,24
-Size=593,631
+Size=370,436
 Collapsed=0
 DockId=0x00000005,0
 
@@ -34,25 +34,25 @@ Size=1421,1027
 Collapsed=0
 
 [Window][Properties]
-Pos=0,657
-Size=593,730
+Pos=0,462
+Size=370,551
 Collapsed=0
 DockId=0x00000006,0
 
 [Window][Stats]
-Pos=2187,24
-Size=373,1363
+Pos=1640,24
+Size=280,989
 Collapsed=0
 DockId=0x00000008,0
 
 [Docking][Data]
-DockSpace       ID=0x3BC79352 Window=0x4647B76E Pos=0,47 Size=2560,1363 Split=X Selected=0x995B0CF8
-  DockNode      ID=0x00000007 Parent=0x3BC79352 SizeRef=1365,1094 Split=X
+DockSpace       ID=0x3BC79352 Window=0x4647B76E Pos=0,53 Size=1920,989 Split=X Selected=0x995B0CF8
+  DockNode      ID=0x00000007 Parent=0x3BC79352 SizeRef=1638,1094 Split=X
     DockNode    ID=0x00000001 Parent=0x00000007 SizeRef=370,696 Split=Y Selected=0x9A68760C
-      DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=593,322 Selected=0x9A68760C
-      DockNode  ID=0x00000006 Parent=0x00000001 SizeRef=593,372 Selected=0xC89E3217
-    DockNode    ID=0x00000002 Parent=0x00000007 SizeRef=993,696 Split=X
-      DockNode  ID=0x00000003 Parent=0x00000002 SizeRef=958,701 CentralNode=1 HiddenTabBar=1 Selected=0x995B0CF8
+      DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=593,436 Selected=0x9A68760C
+      DockNode  ID=0x00000006 Parent=0x00000001 SizeRef=593,551 Selected=0xC89E3217
+    DockNode    ID=0x00000002 Parent=0x00000007 SizeRef=1266,696 Split=X
+      DockNode  ID=0x00000003 Parent=0x00000002 SizeRef=958,701 CentralNode=1 Selected=0x995B0CF8
       DockNode  ID=0x00000004 Parent=0x00000002 SizeRef=272,701 Selected=0x1C33C293
-  DockNode      ID=0x00000008 Parent=0x3BC79352 SizeRef=233,1094 Selected=0x968648AE
+  DockNode      ID=0x00000008 Parent=0x3BC79352 SizeRef=280,1094 Selected=0x968648AE
 

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -261,6 +261,7 @@ namespace Hazel {
 
 			if (ImGuizmo::IsUsing())
 			{
+				m_IsGizmoInUse = true;
 				glm::vec3 translation, rotation, scale;
 				Math::DecomposeTransform(transform, translation, rotation, scale);
 
@@ -269,8 +270,11 @@ namespace Hazel {
 				tc.Rotation += deltaRotation;
 				tc.Scale = scale;
 			}
-		}
+			else {
+				m_IsGizmoInUse = false;
+			}
 
+		}
 
 		ImGui::End();
 		ImGui::PopStyleVar();
@@ -320,16 +324,28 @@ namespace Hazel {
 
 			// Gizmos
 			case Key::Q:
-				m_GizmoType = -1;
+				if (!m_IsGizmoInUse)
+				{
+					m_GizmoType = -1;
+				}
 				break;
 			case Key::W:
-				m_GizmoType = ImGuizmo::OPERATION::TRANSLATE;
+				if (!m_IsGizmoInUse)
+				{
+					m_GizmoType = ImGuizmo::OPERATION::TRANSLATE;
+				}
 				break;
 			case Key::E:
-				m_GizmoType = ImGuizmo::OPERATION::ROTATE;
+				if (!m_IsGizmoInUse)
+				{
+					m_GizmoType = ImGuizmo::OPERATION::ROTATE;
+				}
 				break;
 			case Key::R:
-				m_GizmoType = ImGuizmo::OPERATION::SCALE;
+				if (!m_IsGizmoInUse)
+				{
+					m_GizmoType = ImGuizmo::OPERATION::SCALE;
+				}
 				break;
 		}
 	}

--- a/Hazelnut/src/EditorLayer.h
+++ b/Hazelnut/src/EditorLayer.h
@@ -46,6 +46,7 @@ namespace Hazel {
 		glm::vec4 m_SquareColor = { 0.2f, 0.3f, 0.8f, 1.0f };
 
 		int m_GizmoType = -1;
+		bool m_IsGizmoInUse = false;
 
 		// Panels
 		SceneHierarchyPanel m_SceneHierarchyPanel;

--- a/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
@@ -45,7 +45,20 @@ namespace Hazel {
 		if (ImGui::BeginPopupContextWindow(0, 1, false))
 		{
 			if (ImGui::MenuItem("Create Empty Entity"))
-				m_Context->CreateEntity("Empty Entity");
+				m_SelectionContext = m_Context->CreateEntity("Empty Entity");
+
+			else if (ImGui::MenuItem("Create Camera"))
+			{
+				m_SelectionContext = m_Context->CreateEntity("Camera");
+				m_SelectionContext.AddComponent<CameraComponent>();
+				ImGui::CloseCurrentPopup();
+			}
+			else if (ImGui::MenuItem("Create Sprite"))
+			{
+				m_SelectionContext = m_Context->CreateEntity("Sprite");
+				m_SelectionContext.AddComponent<SpriteRendererComponent>();
+				ImGui::CloseCurrentPopup();
+			}
 
 			ImGui::EndPopup();
 		}


### PR DESCRIPTION
#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:
- No crash when changing gizmo type while using it
- Directly create camera and sprite Entity
- Newly created entity will be selected (nice to have because we don't need to select it after creating it)
- New Theme

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Closes #390 
Other PRs this solves    | None 

#### Proposed fix _(Make sure you've read [on how to contribute] (https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
- No crash when changing gizmo type by pressing Q/W/E/R while using it.
- Directly create camera and sprite Entity
- Newly created entity will be selected (nice to have because we don't need to select it after creating it)
- New Theme and changed the function so can change to different theme easily.

#### Additional context
- No crash when changing gizmo type by pressing Q/W/E/R while using it.

![Gizmo Bug](https://user-images.githubusercontent.com/54288405/101510017-6448ad80-399f-11eb-9d16-b79ead33f5f2.gif)

- Directly create camera and sprite Entity
- Newly created entity will be selected (nice to have because we don't need to select it after creating it)

![NewEntityUtil](https://user-images.githubusercontent.com/54288405/101510038-690d6180-399f-11eb-94fa-9315b1423339.gif)


- New Theme

![NewTheme](https://user-images.githubusercontent.com/54288405/101510067-70cd0600-399f-11eb-883f-b29f24f0d560.gif)

I have already made an issue #393 about viewport background color does not change with theme change
