### PR TITLE
Ref now get's created using CreateRef() in Log class

### DIFF
--- a/Hazel/src/Hazel/Core/Log.cpp
+++ b/Hazel/src/Hazel/Core/Log.cpp
@@ -5,7 +5,6 @@
 #include <spdlog/sinks/basic_file_sink.h>
 
 namespace Hazel {
-
 	Ref<spdlog::logger> Log::s_CoreLogger;
 	Ref<spdlog::logger> Log::s_ClientLogger;
 
@@ -18,16 +17,14 @@ namespace Hazel {
 		logSinks[0]->set_pattern("%^[%T] %n: %v%$");
 		logSinks[1]->set_pattern("[%T] [%l] %n: %v");
 
-		s_CoreLogger = std::make_shared<spdlog::logger>("HAZEL", begin(logSinks), end(logSinks));
+		s_CoreLogger = CreateRef<spdlog::logger>("HAZEL", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_CoreLogger);
 		s_CoreLogger->set_level(spdlog::level::trace);
 		s_CoreLogger->flush_on(spdlog::level::trace);
 
-		s_ClientLogger = std::make_shared<spdlog::logger>("APP", begin(logSinks), end(logSinks));
+		s_ClientLogger = CreateRef<spdlog::logger>("APP", begin(logSinks), end(logSinks));
 		spdlog::register_logger(s_ClientLogger);
 		s_ClientLogger->set_level(spdlog::level::trace);
 		s_ClientLogger->flush_on(spdlog::level::trace);
 	}
-
 }
-


### PR DESCRIPTION
#### Describe the issue
In Log class, `s_CoreLogger` and `s_ClientLogger` are Refs, an alias for `std::shared_ptr`. However they are getting created using `std::make_shared` instead of `CreateRef()` in the Log class. This leads to code convention inconsistency.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix
Replaced `std::make_shared` with `CreateRef()`.
