### PR TITLE
Now can directly create Sprite and Camera Entity

### DIFF
--- a/Hazelnut/imgui.ini
+++ b/Hazelnut/imgui.ini
@@ -1,10 +1,10 @@
 [Window][DockSpace Demo]
 Pos=0,0
-Size=1600,900
+Size=1920,1013
 Collapsed=0
 
 [Window][Debug##Default]
-ViewportPos=1180,1184
+ViewportPos=1180,1023
 ViewportId=0x9F5F46A1
 Size=400,400
 Collapsed=0
@@ -17,13 +17,13 @@ DockId=0x00000004,0
 
 [Window][Viewport]
 Pos=372,24
-Size=993,876
+Size=1266,989
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][Scene Hierarchy]
 Pos=0,24
-Size=370,406
+Size=370,458
 Collapsed=0
 DockId=0x00000005,0
 
@@ -34,19 +34,19 @@ Size=1421,1027
 Collapsed=0
 
 [Window][Properties]
-Pos=0,432
-Size=370,468
+Pos=0,484
+Size=370,529
 Collapsed=0
 DockId=0x00000006,0
 
 [Window][Stats]
-Pos=1367,24
-Size=233,876
+Pos=1640,24
+Size=280,989
 Collapsed=0
 DockId=0x00000008,0
 
 [Docking][Data]
-DockSpace       ID=0x3BC79352 Window=0x4647B76E Pos=268,341 Size=1600,876 Split=X Selected=0x995B0CF8
+DockSpace       ID=0x3BC79352 Window=0x4647B76E Pos=0,53 Size=1920,989 Split=X Selected=0x995B0CF8
   DockNode      ID=0x00000007 Parent=0x3BC79352 SizeRef=1365,1094 Split=X
     DockNode    ID=0x00000001 Parent=0x00000007 SizeRef=370,696 Split=Y Selected=0x9A68760C
       DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=593,322 Selected=0x9A68760C

--- a/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
@@ -45,7 +45,19 @@ namespace Hazel {
 		if (ImGui::BeginPopupContextWindow(0, 1, false))
 		{
 			if (ImGui::MenuItem("Create Empty Entity"))
-				m_Context->CreateEntity("Empty Entity");
+				m_SelectionContext = m_Context->CreateEntity("Empty Entity");
+			else if (ImGui::MenuItem("Create Camera"))
+			{
+				m_SelectionContext = m_Context->CreateEntity("Camera");
+				m_SelectionContext.AddComponent<CameraComponent>();
+				ImGui::CloseCurrentPopup();
+			}
+			else if (ImGui::MenuItem("Create Sprite"))
+			{
+				m_SelectionContext = m_Context->CreateEntity("Sprite");
+				m_SelectionContext.AddComponent<SpriteRendererComponent>();
+				ImGui::CloseCurrentPopup();
+			}
 
 			ImGui::EndPopup();
 		}


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
I have to manually select the created entity but now created entity is automatically selected and now directly create sprite and camera component.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
As we created "Empty Entity" just like that we can create sprite and camera entity directly.

#### Additional context
![NewEntityUtil](https://user-images.githubusercontent.com/54288405/101976416-fae5ca80-3c3c-11eb-8f4e-450f95ff5e9c.gif)
