### PR TITLE
ImGuizmo Crash Fix

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -303,8 +303,11 @@ namespace Hazel {
 		if (e.GetRepeatCount() > 0)
 			return false;
 
+		int gizmoChange = -2;
+
 		bool control = Input::IsKeyPressed(Key::LeftControl) || Input::IsKeyPressed(Key::RightControl);
 		bool shift = Input::IsKeyPressed(Key::LeftShift) || Input::IsKeyPressed(Key::RightShift);
+
 		switch (e.GetKeyCode())
 		{
 			case Key::N:
@@ -331,17 +334,31 @@ namespace Hazel {
 
 			// Gizmos
 			case Key::Q:
-				m_GizmoType = -1;
+			{
+				gizmoChange = -1;
 				break;
+			}
 			case Key::W:
-				m_GizmoType = ImGuizmo::OPERATION::TRANSLATE;
+			{
+				gizmoChange = ImGuizmo::OPERATION::TRANSLATE;
 				break;
+			}
 			case Key::E:
-				m_GizmoType = ImGuizmo::OPERATION::ROTATE;
+			{
+				gizmoChange = ImGuizmo::OPERATION::ROTATE;
 				break;
+			}
 			case Key::R:
-				m_GizmoType = ImGuizmo::OPERATION::SCALE;
+			{
+				gizmoChange = ImGuizmo::OPERATION::SCALE;
 				break;
+			}
+		}
+
+		if(gizmoChange != -2 && gizmoChange != m_GizmoType) {
+			ImGuizmo::Enable(false);
+			ImGuizmo::Enable(true);
+			m_GizmoType = gizmoChange;
 		}
 	}
 

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -303,8 +303,6 @@ namespace Hazel {
 		if (e.GetRepeatCount() > 0)
 			return false;
 
-		bool canGizmoChange = !ImGuizmo::IsUsing();
-
 		bool control = Input::IsKeyPressed(Key::LeftControl) || Input::IsKeyPressed(Key::RightControl);
 		bool shift = Input::IsKeyPressed(Key::LeftShift) || Input::IsKeyPressed(Key::RightShift);
 
@@ -335,25 +333,25 @@ namespace Hazel {
 			// Gizmos
 			case Key::Q:
 			{
-				if (canGizmoChange)
+				if (!ImGuizmo::IsUsing())
 					m_GizmoType = -1;
 				break;
 			}
 			case Key::W:
 			{
-				if (canGizmoChange)
+				if (!ImGuizmo::IsUsing())
 					m_GizmoType = ImGuizmo::OPERATION::TRANSLATE;
 				break;
 			}
 			case Key::E:
 			{
-				if (canGizmoChange)
+				if (!ImGuizmo::IsUsing())
 					m_GizmoType = ImGuizmo::OPERATION::ROTATE;
 				break;
 			}
 			case Key::R:
 			{
-				if (canGizmoChange)
+				if (!ImGuizmo::IsUsing())
 					m_GizmoType = ImGuizmo::OPERATION::SCALE;
 				break;
 			}

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -303,7 +303,7 @@ namespace Hazel {
 		if (e.GetRepeatCount() > 0)
 			return false;
 
-		int gizmoChange = -2;
+		bool canGizmoChange = !ImGuizmo::IsUsing();
 
 		bool control = Input::IsKeyPressed(Key::LeftControl) || Input::IsKeyPressed(Key::RightControl);
 		bool shift = Input::IsKeyPressed(Key::LeftShift) || Input::IsKeyPressed(Key::RightShift);
@@ -335,30 +335,28 @@ namespace Hazel {
 			// Gizmos
 			case Key::Q:
 			{
-				gizmoChange = -1;
+				if (canGizmoChange)
+					m_GizmoType = -1;
 				break;
 			}
 			case Key::W:
 			{
-				gizmoChange = ImGuizmo::OPERATION::TRANSLATE;
+				if (canGizmoChange)
+					m_GizmoType = ImGuizmo::OPERATION::TRANSLATE;
 				break;
 			}
 			case Key::E:
 			{
-				gizmoChange = ImGuizmo::OPERATION::ROTATE;
+				if (canGizmoChange)
+					m_GizmoType = ImGuizmo::OPERATION::ROTATE;
 				break;
 			}
 			case Key::R:
 			{
-				gizmoChange = ImGuizmo::OPERATION::SCALE;
+				if (canGizmoChange)
+					m_GizmoType = ImGuizmo::OPERATION::SCALE;
 				break;
 			}
-		}
-
-		if(gizmoChange != -2 && gizmoChange != m_GizmoType) {
-			ImGuizmo::Enable(false);
-			ImGuizmo::Enable(true);
-			m_GizmoType = gizmoChange;
 		}
 	}
 


### PR DESCRIPTION
The issue

When you change a gizmo while using it, it will crash entire engine.


List of related issues/PRs this will solve:
- Crash when changing gizmos while using them #383

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Resolves #383
Other PRs this solves    | None

Proposed fix:

Disable and Enabel ImGuizmos after gizmo change.
