### PR TITLE
At GLFW input check, removed "button state" check which is never invoked.

### DIFF
--- a/Hazel/src/Platform/Windows/WindowsInput.cpp
+++ b/Hazel/src/Platform/Windows/WindowsInput.cpp
@@ -10,7 +10,7 @@ namespace Hazel {
 	{
 		auto* window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
 		auto state = glfwGetKey(window, static_cast<int32_t>(key));
-		return state == GLFW_PRESS || state == GLFW_REPEAT;
+		return state == GLFW_PRESS;
 	}
 
 	bool Input::IsMouseButtonPressed(const MouseCode button)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
In `WindowsInput` class implementation, in function `Input::IsKeyPressed` the GLFW window is checked for key press. We're performing 2 checks there (1 for button pressed and 1 for button repeat), but from the description of the `GLFWwindow::glfwGetKey`, this "repeat" will never be invoked. Details below + link to [description](https://github.com/TheCherno/glfw/blob/4fba735d5eaa60e685195aeac8f30c1460ab2a97/include/GLFW/glfw3.h#L4353):

> /*! @brief Returns the last reported state of a mouse button for the specified window.
> *  This function returns the last state reported for the specified mouse button to the specified window.  The returned state is one of `GLFW_PRESS` or `GLFW_RELEASE`.
> *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.


#### Proposed fix
This PR removes needless check for the `GLFW_REPEAT`.