### PR TITLE
Assert single instance of ImGuiLayer

### DIFF
--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
@@ -15,6 +15,8 @@
 
 namespace Hazel {
 
+	ImGuiLayer* ImGuiLayer::s_Instance = nullptr;
+
 	ImGuiLayer::ImGuiLayer()
 		: Layer("ImGuiLayer")
 	{
@@ -23,6 +25,9 @@ namespace Hazel {
 	void ImGuiLayer::OnAttach()
 	{
 		HZ_PROFILE_FUNCTION();
+
+		HZ_CORE_ASSERT(!s_Instance, "ImGuiLayer already exists!");
+		s_Instance = this;
 
 		// Setup Dear ImGui context
 		IMGUI_CHECKVERSION();

--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.h
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.h
@@ -27,6 +27,7 @@ namespace Hazel {
 	private:
 		bool m_BlockEvents = true;
 		float m_Time = 0.0f;
+		static ImGuiLayer* s_Instance;
 	};
 
 }


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Multiple instances of ImGuiLayer could be created and pushed into the Application's LayerStack, resulting in ImGui being initialized more than once in OnAttach function.

#### Proposed fix 
Assert single instance in ImGuiLayer's constructor.
