### PR TITLE
Fix wrong viewport bounds when tab is visible

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -236,18 +236,16 @@ namespace Hazel {
 
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{ 0, 0 });
 		ImGui::Begin("Viewport");
-		{
-			ImVec2 minBound = ImGui::GetWindowContentRegionMin();
-			ImVec2 maxBound = ImGui::GetWindowContentRegionMax();
+		ImVec2 minBound = ImGui::GetWindowContentRegionMin();
+		ImVec2 maxBound = ImGui::GetWindowContentRegionMax();
 
-			minBound.x += ImGui::GetWindowPos().x;
-			minBound.y += ImGui::GetWindowPos().y;
-			maxBound.x += ImGui::GetWindowPos().x;
-			maxBound.y += ImGui::GetWindowPos().y;
+		minBound.x += ImGui::GetWindowPos().x;
+		minBound.y += ImGui::GetWindowPos().y;
+		maxBound.x += ImGui::GetWindowPos().x;
+		maxBound.y += ImGui::GetWindowPos().y;
 
-			m_ViewportBounds[0] = { minBound.x, minBound.y };
-			m_ViewportBounds[1] = { maxBound.x, maxBound.y };
-		}
+		m_ViewportBounds[0] = { minBound.x, minBound.y };
+		m_ViewportBounds[1] = { maxBound.x, maxBound.y };
 
 		m_ViewportFocused = ImGui::IsWindowFocused();
 		m_ViewportHovered = ImGui::IsWindowHovered();
@@ -266,9 +264,7 @@ namespace Hazel {
 			ImGuizmo::SetOrthographic(false);
 			ImGuizmo::SetDrawlist();
 
-			float windowWidth = (float)ImGui::GetWindowWidth();
-			float windowHeight = (float)ImGui::GetWindowHeight();
-			ImGuizmo::SetRect(ImGui::GetWindowPos().x, ImGui::GetWindowPos().y, windowWidth, windowHeight);
+			ImGuizmo::SetRect(minBound.x, minBound.y, maxBound.x - minBound.x, maxBound.y - minBound.y);
 
 			// Camera
 			

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -236,7 +236,18 @@ namespace Hazel {
 
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{ 0, 0 });
 		ImGui::Begin("Viewport");
-		auto viewportOffset = ImGui::GetCursorPos(); // Includes tab bar
+		{
+			ImVec2 minBound = ImGui::GetWindowContentRegionMin();
+			ImVec2 maxBound = ImGui::GetWindowContentRegionMax();
+
+			minBound.x += ImGui::GetWindowPos().x;
+			minBound.y += ImGui::GetWindowPos().y;
+			maxBound.x += ImGui::GetWindowPos().x;
+			maxBound.y += ImGui::GetWindowPos().y;
+
+			m_ViewportBounds[0] = { minBound.x, minBound.y };
+			m_ViewportBounds[1] = { maxBound.x, maxBound.y };
+		}
 
 		m_ViewportFocused = ImGui::IsWindowFocused();
 		m_ViewportHovered = ImGui::IsWindowHovered();
@@ -247,15 +258,6 @@ namespace Hazel {
 
 		uint64_t textureID = m_Framebuffer->GetColorAttachmentRendererID();
 		ImGui::Image(reinterpret_cast<void*>(textureID), ImVec2{ m_ViewportSize.x, m_ViewportSize.y }, ImVec2{ 0, 1 }, ImVec2{ 1, 0 });
-
-		auto windowSize = ImGui::GetWindowSize();
-		ImVec2 minBound = ImGui::GetWindowPos();
-		minBound.x += viewportOffset.x;
-		minBound.y += viewportOffset.y;
-
-		ImVec2 maxBound = { minBound.x + windowSize.x, minBound.y + windowSize.y };
-		m_ViewportBounds[0] = { minBound.x, minBound.y };
-		m_ViewportBounds[1] = { maxBound.x, maxBound.y };
 
 		// Gizmos
 		Entity selectedEntity = m_SceneHierarchyPanel.GetSelectedEntity();

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -236,16 +236,11 @@ namespace Hazel {
 
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{ 0, 0 });
 		ImGui::Begin("Viewport");
-		ImVec2 minBound = ImGui::GetWindowContentRegionMin();
-		ImVec2 maxBound = ImGui::GetWindowContentRegionMax();
-
-		minBound.x += ImGui::GetWindowPos().x;
-		minBound.y += ImGui::GetWindowPos().y;
-		maxBound.x += ImGui::GetWindowPos().x;
-		maxBound.y += ImGui::GetWindowPos().y;
-
-		m_ViewportBounds[0] = { minBound.x, minBound.y };
-		m_ViewportBounds[1] = { maxBound.x, maxBound.y };
+		auto viewportMinRegion = ImGui::GetWindowContentRegionMin();
+		auto viewportMaxRegion = ImGui::GetWindowContentRegionMax();
+		auto viewportOffset = ImGui::GetWindowPos();
+		m_ViewportBounds[0] = { viewportMinRegion.x + viewportOffset.x, viewportMinRegion.y + viewportOffset.y };
+		m_ViewportBounds[1] = { viewportMaxRegion.x + viewportOffset.x, viewportMaxRegion.y + viewportOffset.y };
 
 		m_ViewportFocused = ImGui::IsWindowFocused();
 		m_ViewportHovered = ImGui::IsWindowHovered();
@@ -264,7 +259,7 @@ namespace Hazel {
 			ImGuizmo::SetOrthographic(false);
 			ImGuizmo::SetDrawlist();
 
-			ImGuizmo::SetRect(minBound.x, minBound.y, maxBound.x - minBound.x, maxBound.y - minBound.y);
+			ImGuizmo::SetRect(m_ViewportBounds[0].x, m_ViewportBounds[0].y, m_ViewportBounds[1].x - m_ViewportBounds[0].x, m_ViewportBounds[1].y - m_ViewportBounds[0].y);
 
 			// Camera
 			


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The viewport bound does not account for the tab bar correctly. As a result, when the tab bar is visible, the mouse picking is vertically offset. Also, when the cursor is right below the tab bar, `Framebuffer::ReadPixel()` returns an undefined integer.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/32969553/107602445-68cb5580-6bde-11eb-98a4-0de5cc446eb0.gif)

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Resolves #401
Other PRs this solves    | Closes #402

#### Proposed fix 
Redefine m_ViewportBounds in EditorLayer.cpp by using `ImGui::GetWindowContentRegionMin()` and `ImGui::GetWindowContentRegionMax()` instead of `ImGui::GetCursorPos()`.

#### Additional context
The fix works with a visible and a hidden viewport tab bar.

Using `ImGui::GetForegroundDrawList()->AddRect(minBound, maxBound, IM_COL32(255, 255, 0, 255));` in EditorLayer.cpp to highlight the viewport edges also shows the viewport vertical bounds is not correct when the tab bar is present.

Before fix (note the bottom edge):
![bug](https://user-images.githubusercontent.com/32969553/107602946-1a1ebb00-6be0-11eb-9856-09c5c0335f6c.png)

After fix:
![fix](https://user-images.githubusercontent.com/32969553/107602956-21de5f80-6be0-11eb-9d17-cbf017a72aa2.png)

___
Edit by @LovelySanta: Added PR impact and moved parts of description to additional context