### PR TITLE
Input processing moved to top of game loop.

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -86,6 +86,8 @@ namespace Hazel {
 
 			if (!m_Minimized)
 			{
+				m_Window->ProcessInput();
+
 				{
 					HZ_PROFILE_SCOPE("LayerStack OnUpdate");
 

--- a/Hazel/src/Hazel/Core/Window.h
+++ b/Hazel/src/Hazel/Core/Window.h
@@ -29,6 +29,7 @@ namespace Hazel {
 
 		virtual ~Window() = default;
 
+		virtual void ProcessInput() = 0;
 		virtual void OnUpdate() = 0;
 
 		virtual uint32_t GetWidth() const = 0;

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -172,11 +172,14 @@ namespace Hazel {
 		}
 	}
 
+	void WindowsWindow::ProcessInput() {
+		glfwPollEvents();
+	}
+
 	void WindowsWindow::OnUpdate()
 	{
 		HZ_PROFILE_FUNCTION();
 
-		glfwPollEvents();
 		m_Context->SwapBuffers();
 	}
 

--- a/Hazel/src/Platform/Windows/WindowsWindow.h
+++ b/Hazel/src/Platform/Windows/WindowsWindow.h
@@ -13,6 +13,7 @@ namespace Hazel {
 		WindowsWindow(const WindowProps& props);
 		virtual ~WindowsWindow();
 
+		void ProcessInput() override;
 		void OnUpdate() override;
 
 		unsigned int GetWidth() const override { return m_Data.Width; }


### PR DESCRIPTION
As I'm currently working on a DirectX implementation I came across a problem where resizing the window would cause artifacts in the form of the title of viewports being malformed and the clear color, that's being drawn behind the viewports, becomes visible for a brief but very noticable moment.

This seems to be happening because the input processing is happening very late in the game loop. Handling input processing as the first thing eliminates this issue.

![ss](https://user-images.githubusercontent.com/11921307/109368339-12763c00-7899-11eb-87b9-0cd5bccd8128.jpg)

