### PR TITLE
Removed 'm_Time' in ImGuiLayer

### DIFF
--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.h
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.h
@@ -26,7 +26,6 @@ namespace Hazel {
 		void SetDarkThemeColors();
 	private:
 		bool m_BlockEvents = true;
-		float m_Time = 0.0f;
 	};
 
 }


### PR DESCRIPTION
Removed the variable 'm_Time' because it is no longer used in 'ImGuiLayer.cpp'.