### PR TITLE
DSA

### DIFF
--- a/Hazel/src/Hazel/Renderer/Buffer.h
+++ b/Hazel/src/Hazel/Renderer/Buffer.h
@@ -113,6 +113,8 @@ namespace Hazel {
 		virtual const BufferLayout& GetLayout() const = 0;
 		virtual void SetLayout(const BufferLayout& layout) = 0;
 
+		virtual uint32_t GetBufferHandle() const = 0;
+
 		static Ref<VertexBuffer> Create(uint32_t size);
 		static Ref<VertexBuffer> Create(float* vertices, uint32_t size);
 	};
@@ -127,6 +129,8 @@ namespace Hazel {
 		virtual void Unbind() const = 0;
 
 		virtual uint32_t GetCount() const = 0;
+
+		virtual uint32_t GetBufferHandle() const = 0;
 
 		static Ref<IndexBuffer> Create(uint32_t* indices, uint32_t count);
 	};

--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -14,8 +14,7 @@ namespace Hazel {
 		HZ_PROFILE_FUNCTION();
 
 		glCreateBuffers(1, &m_RendererID);
-		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ARRAY_BUFFER, size, nullptr, GL_DYNAMIC_DRAW);
+		glNamedBufferData(m_RendererID, size, nullptr, GL_DYNAMIC_DRAW);
 	}
 
 	OpenGLVertexBuffer::OpenGLVertexBuffer(float* vertices, uint32_t size)
@@ -23,8 +22,7 @@ namespace Hazel {
 		HZ_PROFILE_FUNCTION();
 
 		glCreateBuffers(1, &m_RendererID);
-		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ARRAY_BUFFER, size, vertices, GL_STATIC_DRAW);
+		glNamedBufferData(m_RendererID, size, vertices, GL_STATIC_DRAW);
 	}
 
 	OpenGLVertexBuffer::~OpenGLVertexBuffer()
@@ -50,8 +48,7 @@ namespace Hazel {
 
 	void OpenGLVertexBuffer::SetData(const void* data, uint32_t size)
 	{
-		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
-		glBufferSubData(GL_ARRAY_BUFFER, 0, size, data);
+		glNamedBufferSubData(m_RendererID, 0, size, data);
 	}
 
 	/////////////////////////////////////////////////////////////////////////////
@@ -64,11 +61,7 @@ namespace Hazel {
 		HZ_PROFILE_FUNCTION();
 
 		glCreateBuffers(1, &m_RendererID);
-		
-		// GL_ELEMENT_ARRAY_BUFFER is not valid without an actively bound VAO
-		// Binding with GL_ARRAY_BUFFER allows the data to be loaded regardless of VAO state. 
-		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
+		glNamedBufferData(m_RendererID, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
 	}
 
 	OpenGLIndexBuffer::~OpenGLIndexBuffer()

--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.h
@@ -18,6 +18,8 @@ namespace Hazel {
 
 		virtual const BufferLayout& GetLayout() const override { return m_Layout; }
 		virtual void SetLayout(const BufferLayout& layout) override { m_Layout = layout; }
+
+		virtual uint32_t GetBufferHandle() const override { return m_RendererID; }
 	private:
 		uint32_t m_RendererID;
 		BufferLayout m_Layout;
@@ -33,6 +35,8 @@ namespace Hazel {
 		virtual void Unbind() const;
 
 		virtual uint32_t GetCount() const { return m_Count; }
+
+		virtual uint32_t GetBufferHandle() const override { return m_RendererID; }
 	private:
 		uint32_t m_RendererID;
 		uint32_t m_Count;

--- a/Hazel/src/Platform/OpenGL/OpenGLFramebuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLFramebuffer.cpp
@@ -21,7 +21,6 @@ namespace Hazel {
 
 		static void BindTexture(bool multisampled, uint32_t id)
 		{
-			//glBindTexture(TextureTarget(multisampled), id);
 			glBindTextureUnit(0, id);
 		}
 
@@ -44,7 +43,6 @@ namespace Hazel {
 			}
 
 			glNamedFramebufferTexture(fbo, GL_COLOR_ATTACHMENT0 + index, id, 0);
-			//glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, TextureTarget(multisampled), id, 0);
 		}
 
 		static void AttachDepthTexture(uint32_t fbo, uint32_t id, int samples, GLenum format, GLenum attachmentType, uint32_t width, uint32_t height)
@@ -53,7 +51,6 @@ namespace Hazel {
 			if (multisampled)
 			{
 				glTextureStorage2DMultisample(id, samples, format, width, height, GL_FALSE);
-				//glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, format, width, height, GL_FALSE);
 			}
 			else
 			{
@@ -68,7 +65,6 @@ namespace Hazel {
 			}
 
 			glNamedFramebufferTexture(fbo, attachmentType, id, 0);
-			//glFramebufferTexture2D(GL_FRAMEBUFFER, attachmentType, TextureTarget(multisampled), id, 0);
 		}
 
 		static bool IsDepthFormat(FramebufferTextureFormat format)

--- a/Hazel/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -34,7 +34,7 @@ namespace Hazel {
 		glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
 		glDebugMessageCallback(OpenGLMessageCallback, nullptr);
 		
-		glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_NOTIFICATION, 0, NULL, GL_FALSE);
+		glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_NOTIFICATION, 0, NULL, GL_TRUE);
 	#endif
 
 		glEnable(GL_BLEND);

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -66,59 +66,18 @@ namespace Hazel {
 		const auto& layout = vertexBuffer->GetLayout();
 		for (const auto& element : layout)
 		{
-			switch (element.Type)
-			{
-				case ShaderDataType::Float:
-				case ShaderDataType::Float2:
-				case ShaderDataType::Float3:
-				case ShaderDataType::Float4:
-				{
-					glEnableVertexAttribArray(m_VertexBufferIndex);
-					glVertexAttribPointer(m_VertexBufferIndex,
-						element.GetComponentCount(),
-						ShaderDataTypeToOpenGLBaseType(element.Type),
-						element.Normalized ? GL_TRUE : GL_FALSE,
-						layout.GetStride(),
-						(const void*)element.Offset);
-					m_VertexBufferIndex++;
-					break;
-				}
-				case ShaderDataType::Int:
-				case ShaderDataType::Int2:
-				case ShaderDataType::Int3:
-				case ShaderDataType::Int4:
-				case ShaderDataType::Bool:
-				{
-					glEnableVertexAttribArray(m_VertexBufferIndex);
-					glVertexAttribIPointer(m_VertexBufferIndex,
-						element.GetComponentCount(),
-						ShaderDataTypeToOpenGLBaseType(element.Type),
-						layout.GetStride(),
-						(const void*)element.Offset);
-					m_VertexBufferIndex++;
-					break;
-				}
-				case ShaderDataType::Mat3:
-				case ShaderDataType::Mat4:
-				{
-					uint8_t count = element.GetComponentCount();
-					for (uint8_t i = 0; i < count; i++)
-					{
-						glEnableVertexAttribArray(m_VertexBufferIndex);
-						glVertexAttribPointer(m_VertexBufferIndex,
-							count,
-							ShaderDataTypeToOpenGLBaseType(element.Type),
-							element.Normalized ? GL_TRUE : GL_FALSE,
-							layout.GetStride(),
-							(const void*)(element.Offset + sizeof(float) * count * i));
-						glVertexAttribDivisor(m_VertexBufferIndex, 1);
-						m_VertexBufferIndex++;
-					}
-					break;
-				}
-				default:
-					HZ_CORE_ASSERT(false, "Unknown ShaderDataType!");
-			}
+			glEnableVertexArrayAttrib(m_RendererID, m_VertexBufferIndex);
+			glVertexArrayVertexBuffer(m_RendererID, m_VertexBufferIndex,
+				vertexBuffer->GetBufferHandle(),
+				element.Offset, layout.GetStride());
+			glVertexArrayAttribFormat(m_RendererID, m_VertexBufferIndex,
+				element.GetComponentCount(),
+				ShaderDataTypeToOpenGLBaseType(element.Type),
+				element.Normalized ? GL_TRUE : GL_FALSE,
+				0);
+
+			glVertexArrayAttribBinding(m_RendererID, m_VertexBufferIndex, m_VertexBufferIndex);
+			m_VertexBufferIndex++;
 		}
 
 		m_VertexBuffers.push_back(vertexBuffer);
@@ -128,9 +87,11 @@ namespace Hazel {
 	{
 		HZ_PROFILE_FUNCTION();
 
-		glBindVertexArray(m_RendererID);
-		indexBuffer->Bind();
+		// bind vao and ibo?
+		//Bind();
+		//indexBuffer->Bind();
 
+		glVertexArrayElementBuffer(m_RendererID, indexBuffer->GetBufferHandle());
 		m_IndexBuffer = indexBuffer;
 	}
 


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Engine is not using OpenGL's Direct State Access which allows us not to bind the buffer/texture/framebuffer to modify the state, like setting the data or configuring it.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Described above
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
The fix basically uses functions that take in renderer id, as such, I had to change VertexBuffer and IndexBuffer to allow to get renderer id. In framebuffer the static utils functions also take in fbo, but the binding inside `Invalidate()` function is left there, because of `glDrawBuffers`

#### Additional context
This has been tested on Windows and shouldn't affect compilability and runnability on other platforms such as Linux.
