### PR TITLE
Remove unnecessary Unbinds

### DIFF
--- a/Hazel/src/Hazel/Renderer/Buffer.h
+++ b/Hazel/src/Hazel/Renderer/Buffer.h
@@ -106,7 +106,6 @@ namespace Hazel {
 		virtual ~VertexBuffer() = default;
 
 		virtual void Bind() const = 0;
-		virtual void Unbind() const = 0;
 
 		virtual void SetData(const void* data, uint32_t size) = 0;
 
@@ -124,7 +123,6 @@ namespace Hazel {
 		virtual ~IndexBuffer() = default;
 
 		virtual void Bind() const = 0;
-		virtual void Unbind() const = 0;
 
 		virtual uint32_t GetCount() const = 0;
 

--- a/Hazel/src/Hazel/Renderer/Shader.h
+++ b/Hazel/src/Hazel/Renderer/Shader.h
@@ -13,7 +13,6 @@ namespace Hazel {
 		virtual ~Shader() = default;
 
 		virtual void Bind() const = 0;
-		virtual void Unbind() const = 0;
 
 		virtual void SetInt(const std::string& name, int value) = 0;
 		virtual void SetIntArray(const std::string& name, int* values, uint32_t count) = 0;

--- a/Hazel/src/Hazel/Renderer/VertexArray.h
+++ b/Hazel/src/Hazel/Renderer/VertexArray.h
@@ -11,7 +11,6 @@ namespace Hazel {
 		virtual ~VertexArray() = default;
 
 		virtual void Bind() const = 0;
-		virtual void Unbind() const = 0;
 
 		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) = 0;
 		virtual void SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer) = 0;

--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -41,13 +41,6 @@ namespace Hazel {
 		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
 	}
 
-	void OpenGLVertexBuffer::Unbind() const
-	{
-		HZ_PROFILE_FUNCTION();
-
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
-	}
-
 	void OpenGLVertexBuffer::SetData(const void* data, uint32_t size)
 	{
 		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
@@ -83,13 +76,6 @@ namespace Hazel {
 		HZ_PROFILE_FUNCTION();
 
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
-	}
-
-	void OpenGLIndexBuffer::Unbind() const
-	{
-		HZ_PROFILE_FUNCTION();
-
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 	}
 
 }

--- a/Hazel/src/Platform/OpenGL/OpenGLBuffer.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLBuffer.h
@@ -12,7 +12,6 @@ namespace Hazel {
 		virtual ~OpenGLVertexBuffer();
 
 		virtual void Bind() const override;
-		virtual void Unbind() const override;
 		
 		virtual void SetData(const void* data, uint32_t size) override;
 
@@ -29,10 +28,9 @@ namespace Hazel {
 		OpenGLIndexBuffer(uint32_t* indices, uint32_t count);
 		virtual ~OpenGLIndexBuffer();
 
-		virtual void Bind() const;
-		virtual void Unbind() const;
+		virtual void Bind() const override;
 
-		virtual uint32_t GetCount() const { return m_Count; }
+		virtual uint32_t GetCount() const override { return m_Count; }
 	private:
 		uint32_t m_RendererID;
 		uint32_t m_Count;

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.cpp
@@ -192,13 +192,6 @@ namespace Hazel {
 		glUseProgram(m_RendererID);
 	}
 
-	void OpenGLShader::Unbind() const
-	{
-		HZ_PROFILE_FUNCTION();
-
-		glUseProgram(0);
-	}
-
 	void OpenGLShader::SetInt(const std::string& name, int value)
 	{
 		HZ_PROFILE_FUNCTION();

--- a/Hazel/src/Platform/OpenGL/OpenGLShader.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLShader.h
@@ -16,7 +16,6 @@ namespace Hazel {
 		virtual ~OpenGLShader();
 
 		virtual void Bind() const override;
-		virtual void Unbind() const override;
 
 		virtual void SetInt(const std::string& name, int value) override;
 		virtual void SetIntArray(const std::string& name, int* values, uint32_t count) override;

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -47,13 +47,6 @@ namespace Hazel {
 		glBindVertexArray(m_RendererID);
 	}
 
-	void OpenGLVertexArray::Unbind() const
-	{
-		HZ_PROFILE_FUNCTION();
-
-		glBindVertexArray(0);
-	}
-
 	void OpenGLVertexArray::AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer)
 	{
 		HZ_PROFILE_FUNCTION();

--- a/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLVertexArray.h
@@ -11,7 +11,6 @@ namespace Hazel {
 		virtual ~OpenGLVertexArray();
 
 		virtual void Bind() const override;
-		virtual void Unbind() const override;
 
 		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) override;
 		virtual void SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer) override;


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Few graphics classes have `Unbind()` function which is never used and pointless.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Described above
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Remove `Unbind()` and add `override` to `OpenGLIndexBuffer`.

#### Additional context
Tested on windows and shouldn't add any problems with compilability and runnability on other OS's like Linux.
