### PR TITLE
Move code to default case in switch statement instead of leaving it outside of the statement

### DIFF
--- a/Hazel/src/Hazel/Renderer/Buffer.cpp
+++ b/Hazel/src/Hazel/Renderer/Buffer.cpp
@@ -13,10 +13,8 @@ namespace Hazel {
 		{
 			case RendererAPI::API::None:    HZ_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
 			case RendererAPI::API::OpenGL:  return CreateRef<OpenGLVertexBuffer>(size);
+			default:                        HZ_CORE_ASSERT(false, "Unknown RendererAPI!"); return nullptr;
 		}
-
-		HZ_CORE_ASSERT(false, "Unknown RendererAPI!");
-		return nullptr;
 	}
 
 	Ref<VertexBuffer> VertexBuffer::Create(float* vertices, uint32_t size)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
The code which handles the case in which a valid rendering API has not been selected is placed outside of the switch block.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Code in function is not consistent       | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Use the _default_ case of the switch statement to control the behaviour if the value is incorrect.

#### Additional context
This solution adds elegance, makes the code easier to read and perhaps allows the compiler to better optimize it.
