### PR TITLE
Removed unnecessary header file

### DIFF
--- a/Hazel/src/Hazel/Utils/PlatformUtils.h
+++ b/Hazel/src/Hazel/Utils/PlatformUtils.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <optional>
 
 namespace Hazel {
 


### PR DESCRIPTION
#### Describe the issue
In the latest commit, which saw the introduction of SPIR-V shader pipeline, the `std::optional<>` part in `PlatformUtils.h` is removed, but not the corresponding include file.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Removed the unnecessary header file.

#### Additional context
The pull request which introduced `std::optional<>` in the first place - https://github.com/TheCherno/Hazel/pull/363
