### PR TITLE
Added post-build commands for copying Vulkan .dlls to output directory

### DIFF
--- a/Dependencies.lua
+++ b/Dependencies.lua
@@ -20,6 +20,7 @@ LibraryDir = {}
 
 LibraryDir["VulkanSDK"] = "%{VULKAN_SDK}/Lib"
 LibraryDir["VulkanSDK_Debug"] = "%{wks.location}/Hazel/vendor/VulkanSDK/Lib"
+LibraryDir["VulkanSDK_DLL"] = "%{wks.location}/Hazel/vendor/VulkanSDK/Bin"
 
 Library = {}
 Library["Vulkan"] = "%{LibraryDir.VulkanSDK}/vulkan-1.lib"

--- a/Hazelnut/premake5.lua
+++ b/Hazelnut/premake5.lua
@@ -27,6 +27,11 @@ project "Hazelnut"
 	{
 		"Hazel"
 	}
+	
+	postbuildcommands
+	{
+		"{COPY} %{LibraryDir.VulkanSDK_DLL} %{wks.location}/bin/" .. outputdir .. "/%{prj.name}"
+	}
 
 	filter "system:windows"
 		systemversion "latest"


### PR DESCRIPTION
#### Describe the issue
After pulling the repository, if we try running Hazelnut, the application crashes because the required `.dll` files at `vendor\VulkanSDK\Bin` are not in proper place.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
A hacky solution without changing any implementation is to manually copy and paste the files in the output directory.
A somewhat automated solution is to use the premake's `postbuildcommand` to copy the files.

#### Additional context
Not the most robust or optimal solution, could be better.