### PR TITLE
Removed debug non-working URL from URL list

### DIFF
--- a/scripts/SetupVulkan.py
+++ b/scripts/SetupVulkan.py
@@ -62,10 +62,8 @@ class VulkanConfiguration:
         shadercdLib = Path(f"{cls.vulkanDirectory}/Lib/shaderc_sharedd.lib")
         
         VulkanSDKDebugLibsURLlist = [
-            f"https://files.lunar.com/VulkanSDK-{cls.requiredVulkanVersion}-DebugLibs.zip",
             f"https://sdk.lunarg.com/sdk/download/{cls.requiredVulkanVersion}/windows/VulkanSDK-{cls.requiredVulkanVersion}-DebugLibs.zip",
             f"https://files.lunarg.com/SDK-{cls.requiredVulkanVersion}/VulkanSDK-{cls.requiredVulkanVersion}-DebugLibs.zip"
-            
         ]
         
         if not shadercdLib.exists():


### PR DESCRIPTION
#### Describe the issue
In PR #438, which got merged, the Python setup scripts got completely reworked, courtesy of @LovelySanta .
One of the features was, the `DownloadFile()` function of `Utils.py` class also accepts a list of URLs to process through.
One of the URLs is a test URL (the 1st one in the list), which was used to test whether the exception handling was getting triggered or not. When the PR got merged, it was still there.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Removed the test URL from the script.
