### PR TITLE
Small refactor of NativeScriptComponent (fixes #336)

### DIFF
--- a/Hazel/src/Hazel.h
+++ b/Hazel/src/Hazel.h
@@ -20,7 +20,7 @@
 
 #include "Hazel/Scene/Scene.h"
 #include "Hazel/Scene/Entity.h"
-#include "Hazel/Scene/ScriptableEntity.h"
+#include "Hazel/Scene/NativeScript.h"
 #include "Hazel/Scene/Components.h"
 
 // ---Renderer------------------------

--- a/Hazel/src/Hazel/Scene/Components.h
+++ b/Hazel/src/Hazel/Scene/Components.h
@@ -7,7 +7,7 @@
 #include <glm/gtx/quaternion.hpp>
 
 #include "SceneCamera.h"
-#include "ScriptableEntity.h"
+#include "NativeScript.h"
 
 namespace Hazel {
 
@@ -64,16 +64,13 @@ namespace Hazel {
 
 	struct NativeScriptComponent
 	{
-		ScriptableEntity* Instance = nullptr;
+		std::function<Scope<NativeScript>(Entity entity)> InstantiateScript;
+		Scope<NativeScript> Instance;
 
-		ScriptableEntity*(*InstantiateScript)();
-		void (*DestroyScript)(NativeScriptComponent*);
-
-		template<typename T>
-		void Bind()
+		template<typename T, typename... Args>
+		void Bind(Args... args)
 		{
-			InstantiateScript = []() { return static_cast<ScriptableEntity*>(new T()); };
-			DestroyScript = [](NativeScriptComponent* nsc) { delete nsc->Instance; nsc->Instance = nullptr; };
+			InstantiateScript = [args...](Entity entity)->Scope<NativeScript> { return CreateScope<T>(entity, args...); };
 		}
 	};
 

--- a/Hazel/src/Hazel/Scene/NativeScript.h
+++ b/Hazel/src/Hazel/Scene/NativeScript.h
@@ -4,24 +4,24 @@
 
 namespace Hazel {
 
-	class ScriptableEntity
+	class NativeScript
 	{
 	public:
-		virtual ~ScriptableEntity() {}
+		NativeScript(Entity entity) : m_Entity(entity) {}
+		virtual ~NativeScript() {}
 
 		template<typename T>
 		T& GetComponent()
 		{
 			return m_Entity.GetComponent<T>();
 		}
+
 	protected:
-		virtual void OnCreate() {}
-		virtual void OnDestroy() {}
 		virtual void OnUpdate(Timestep ts) {}
+
 	private:
 		Entity m_Entity;
 		friend class Scene;
 	};
 
 }
-

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -41,9 +41,7 @@ namespace Hazel {
 				// TODO: Move to Scene::OnScenePlay
 				if (!nsc.Instance)
 				{
-					nsc.Instance = nsc.InstantiateScript();
-					nsc.Instance->m_Entity = Entity{ entity, this };
-					nsc.Instance->OnCreate();
+					nsc.Instance = nsc.InstantiateScript({entity, this});
 				}
 
 				nsc.Instance->OnUpdate(ts);

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -60,17 +60,13 @@ namespace Hazel {
 		auto& cc = m_SecondCamera.AddComponent<CameraComponent>();
 		cc.Primary = false;
 
-		class CameraController : public ScriptableEntity
+		class CameraController : public NativeScript
 		{
 		public:
-			virtual void OnCreate() override
+			CameraController(Entity entity) : NativeScript(entity)
 			{
 				auto& translation = GetComponent<TransformComponent>().Translation;
 				translation.x = rand() % 10 - 5.0f;
-			}
-
-			virtual void OnDestroy() override
-			{
 			}
 
 			virtual void OnUpdate(Timestep ts) override


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Per comments on #336 memory is leaked every time a NativeScriptComponent is instantiated.
This PR addresses that issue, and also makes the following changes:
- renames ScriptableEntity to NativeScript  (so that a NativeScriptComponent wraps a NativeScript, and also the thing called "ScriptableEntity" is not really an entity, but rather a component).
- Changes NativeScriptComponent::Instance into a Hazel::Scope  (this fixes the memory leak)
- Constructor for NativeScript now sets its entity, so that you do not have to remember to do this after calling InstantiateScript()
- Allows passing arbitrary parameters to NativeScriptComponent::InstantiateScript
- Remove not-needed OnCreate()  (put that stuff in your script object's constructor instead)
- Remove not-needed OnDestroy()  (put that stuff in your script object's destructor instead)
- Instantiation of a NativeScript is now one line instead of three.

#### PR impact
As described above
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | #336
Other PRs this solves    | None

#### Proposed fix
The memory leak is fixed because NativeScriptComponent::Instance is now a Hazel::Scope (aka a smart pointer), which automatically calls the destructor when NativeScriptComponent is destroyed.  The destructor is virtual, so the correct derived NativeScript destructor will end up being invoked..

#### Additional context
The PR includes example usage of the refactored NativeScriptComponent in EditorLayer::OnAttach().
I have also fully tested this (on Windows) using my own small game on my fork of Hazel. (see HazelDash on my github if interested)
