### PR TITLE
Updated premake post build to work with white spaces

### DIFF
--- a/vendor/premake/premake5.lua
+++ b/vendor/premake/premake5.lua
@@ -12,5 +12,5 @@ project "Premake"
 	postbuildmessage "Regenerating project files with Premake5!"
 	postbuildcommands
 	{
-		"%{prj.location}bin/premake5 %{_ACTION} --file=\"%{wks.location}premake5.lua\""
+		"\"%{prj.location}bin/premake5\" %{_ACTION} --file=\"%{wks.location}premake5.lua\""
 	}


### PR DESCRIPTION
#### Describe the issue
Paths with white spaces won't work unless the `%{prj.location}bin/premake5` are wrapped in `""` so that the command works properly

#### PR impact 
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix 
Refactored the premake project post build script to work with paths that whitespaces

#### Additional context
Any one having paths with spaces will have a trouble running this command, hence enclosing them quotes will resolve this issue
