### PR TITLE
Added Estimated Time Remaining to Download and Unzip in Utils.py

### DIFF
--- a/scripts/Utils.py
+++ b/scripts/Utils.py
@@ -43,7 +43,7 @@ def DownloadFile(url, filepath):
                 print(f"HTTP Error  encountered: {e.code}. Proceeding with backup...\n\n")
                 os.remove(filepath)
                 pass
-            except Exception:
+            except:
                 print(f"Something went wrong. Proceeding with backup...\n\n")
                 os.remove(filepath)
                 pass


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
This adds a feature.

Now when running setup the Estimated time remaining is shown (Both for downloading and for Unzipping).
Also added a `FormatTime(seconds)`  function which may be used for other parts of setup.


 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None


#### Additional context
Tested on Windows 10
