### PR TITLE
Set staticruntime to off in Glad project

### DIFF
--- a/Hazel/vendor/Glad/premake5.lua
+++ b/Hazel/vendor/Glad/premake5.lua
@@ -1,7 +1,7 @@
 project "Glad"
     kind "StaticLib"
     language "C"
-    staticruntime "on"
+    staticruntime "off"
     
     targetdir ("bin/" .. outputdir .. "/%{prj.name}")
     objdir ("bin-int/" .. outputdir .. "/%{prj.name}")


### PR DESCRIPTION
Set staticruntime off.  No issues yet with it being on but the rest of the projects are off.