### PR TITLE
Updated Texture.glsl To properly work with Textures and SPIR-V

### DIFF
--- a/Hazelnut/assets/shaders/Texture.glsl
+++ b/Hazelnut/assets/shaders/Texture.glsl
@@ -19,20 +19,20 @@ struct VertexOutput
 {
 	vec4 Color;
 	vec2 TexCoord;
-	float TexIndex;
 	float TilingFactor;
 };
 
 layout (location = 0) out VertexOutput Output;
+layout (location = 3) out flat float v_TexIndex;
 layout (location = 4) out flat int v_EntityID;
 
 void main()
 {
 	Output.Color = a_Color;
 	Output.TexCoord = a_TexCoord;
-	Output.TexIndex = a_TexIndex;
 	Output.TilingFactor = a_TilingFactor;
 	v_EntityID = a_EntityID;
+	v_TexIndex = a_TexIndex;
 
 	gl_Position = u_ViewProjection * vec4(a_Position, 1.0);
 }
@@ -47,11 +47,11 @@ struct VertexOutput
 {
 	vec4 Color;
 	vec2 TexCoord;
-	float TexIndex;
 	float TilingFactor;
 };
 
 layout (location = 0) in VertexOutput Input;
+layout (location = 3) in flat float v_TexIndex;
 layout (location = 4) in flat int v_EntityID;
 
 layout (binding = 0) uniform sampler2D u_Textures[32];
@@ -60,7 +60,7 @@ void main()
 {
 	vec4 texColor = Input.Color;
 
-	switch(int(Input.TexIndex))
+	switch(int(v_TexIndex))
 	{
 		case  0: texColor *= texture(u_Textures[ 0], Input.TexCoord * Input.TilingFactor); break;
 		case  1: texColor *= texture(u_Textures[ 1], Input.TexCoord * Input.TilingFactor); break;


### PR DESCRIPTION
#### Textures where showing up incorrectly
Textures are having weird white stripes in rendering

#### PR impact:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix 
Update Texture.glsl to handle flat TexIndex
