### PR TITLE
Fixed typo in Log.h file

### DIFF
--- a/Hazel/src/Hazel/Core/Log.h
+++ b/Hazel/src/Hazel/Core/Log.h
@@ -40,9 +40,9 @@ inline OStream& operator<<(OStream& os, const glm::mat<C, R, T, Q>& matrix)
 }
 
 template<typename OStream, typename T, glm::qualifier Q>
-inline OStream& operator<<(OStream& os, glm::qua<T, Q> quaternio)
+inline OStream& operator<<(OStream& os, glm::qua<T, Q> quaternion)
 {
-	return os << glm::to_string(quaternio);
+	return os << glm::to_string(quaternion);
 }
 
 // Core log macros


### PR DESCRIPTION
#### Describe the issue
In PR #361 , overloaded operators were added to the `Log.h` file to properly convert the `glm` data types into a stream.
One of the operators, the operator for quaternion, has the typo mistake error, where the word "quaternion" is spelled as "quaternio", in it's definition.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Renamed "quaternio" to "quaternion"