### PR TITLE
Drag a texture image directly into the viewport

### DIFF
--- a/Hazelnut/imgui.ini
+++ b/Hazelnut/imgui.ini
@@ -58,7 +58,7 @@ Collapsed=0
 DockId=0x0000000B,0
 
 [Docking][Data]
-DockSpace           ID=0x3BC79352 Window=0x4647B76E Pos=137,190 Size=1600,876 Split=X Selected=0x995B0CF8
+DockSpace           ID=0x3BC79352 Window=0x4647B76E Pos=73,126 Size=1600,876 Split=X Selected=0x995B0CF8
   DockNode          ID=0x00000008 Parent=0x3BC79352 SizeRef=1228,876 Split=X
     DockNode        ID=0x00000001 Parent=0x00000008 SizeRef=370,696 Split=Y Selected=0xC89E3217
       DockNode      ID=0x00000005 Parent=0x00000001 SizeRef=370,435 Selected=0x9A68760C

--- a/Hazelnut/imgui.ini
+++ b/Hazelnut/imgui.ini
@@ -4,7 +4,7 @@ Size=1600,900
 Collapsed=0
 
 [Window][Debug##Default]
-ViewportPos=1180,1184
+ViewportPos=1180,1011
 ViewportId=0x9F5F46A1
 Size=400,400
 Collapsed=0
@@ -58,7 +58,7 @@ Collapsed=0
 DockId=0x0000000B,0
 
 [Docking][Data]
-DockSpace           ID=0x3BC79352 Window=0x4647B76E Pos=294,341 Size=1600,876 Split=X Selected=0x995B0CF8
+DockSpace           ID=0x3BC79352 Window=0x4647B76E Pos=137,190 Size=1600,876 Split=X Selected=0x995B0CF8
   DockNode          ID=0x00000008 Parent=0x3BC79352 SizeRef=1228,876 Split=X
     DockNode        ID=0x00000001 Parent=0x00000008 SizeRef=370,696 Split=Y Selected=0xC89E3217
       DockNode      ID=0x00000005 Parent=0x00000001 SizeRef=370,435 Selected=0x9A68760C

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -287,17 +287,40 @@ namespace Hazel {
 				const wchar_t* path = (const wchar_t*)payload->Data;
 				std::filesystem::path parentPath = std::filesystem::path(path).parent_path();
 
-				if (parentPath == "scenes")			// Load scene
+				// MajiSubhra code to drag texture using directory
+				
+				//if (parentPath == "scenes")			// Load scene
+				//	OpenScene(std::filesystem::path(g_AssetPath) / path);
+				//else if (parentPath == "textures" && name != "None")	// Load texture
+				//{
+				//	std::filesystem::path texturePath = std::filesystem::path(g_AssetPath) / path;
+				//	Ref<Texture2D> texture = Texture2D::Create(texturePath.string());
+				//	if (texture->IsLoaded())
+				//		m_HoveredEntity.GetComponent<SpriteRendererComponent>().Texture = texture;
+				//	else
+				//		HZ_WARN("Could not load texture {0}", texturePath.filename().string());
+				//}
+
+				// VagueLobster code to drag texture using file extension
+
+				std::filesystem::path filePath = std::filesystem::path(path);
+				if (filePath.extension().string() == ".hazel")
+				{
 					OpenScene(std::filesystem::path(g_AssetPath) / path);
-				else if (parentPath == "textures")	// Load texture
+				}
+				else if (filePath.extension().string() == ".png")
 				{
 					std::filesystem::path texturePath = std::filesystem::path(g_AssetPath) / path;
 					Ref<Texture2D> texture = Texture2D::Create(texturePath.string());
 					if (texture->IsLoaded())
-						m_HoveredEntity.GetComponent<SpriteRendererComponent>().Texture = texture;
-					//m_Hcomponent.Texture = texture;
+					{
+						if (m_HoveredEntity && m_HoveredEntity.HasComponent<SpriteRendererComponent>())
+							m_HoveredEntity.GetComponent<SpriteRendererComponent>().Texture = texture;
+					}
 					else
+					{
 						HZ_WARN("Could not load texture {0}", texturePath.filename().string());
+					}
 				}
 			}
 			ImGui::EndDragDropTarget();

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -285,7 +285,20 @@ namespace Hazel {
 			if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("CONTENT_BROWSER_ITEM"))
 			{
 				const wchar_t* path = (const wchar_t*)payload->Data;
-				OpenScene(std::filesystem::path(g_AssetPath) / path);
+				std::filesystem::path parentPath = std::filesystem::path(path).parent_path();
+
+				if (parentPath == "scenes")			// Load scene
+					OpenScene(std::filesystem::path(g_AssetPath) / path);
+				else if (parentPath == "textures")	// Load texture
+				{
+					std::filesystem::path texturePath = std::filesystem::path(g_AssetPath) / path;
+					Ref<Texture2D> texture = Texture2D::Create(texturePath.string());
+					if (texture->IsLoaded())
+						m_HoveredEntity.GetComponent<SpriteRendererComponent>().Texture = texture;
+					//m_Hcomponent.Texture = texture;
+					else
+						HZ_WARN("Could not load texture {0}", texturePath.filename().string());
+				}
 			}
 			ImGui::EndDragDropTarget();
 		}


### PR DESCRIPTION
#### Drag a texture image directly into the viewport

Until now, to add a texture to a sprite renderer component, the image has to be dragged onto the "Texture" button in the scene hierarchy panel. Now, in addition, one can drag a texture image directly onto a component in the viewport.