### PR TITLE
AddComponent code-block refactor

### DIFF
--- a/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
@@ -239,59 +239,12 @@ namespace Hazel {
 
 		if (ImGui::BeginPopup("AddComponent"))
 		{
-				if (!m_SelectionContext.HasComponent<CameraComponent>())
-				{
-					if (ImGui::MenuItem("Camera"))
-					{
-						m_SelectionContext.AddComponent<CameraComponent>();
-						ImGui::CloseCurrentPopup();
-					}
-				}
-
-				if (!m_SelectionContext.HasComponent<SpriteRendererComponent>())
-				{
-					if (ImGui::MenuItem("Sprite Renderer"))
-					{
-						m_SelectionContext.AddComponent<SpriteRendererComponent>();
-						ImGui::CloseCurrentPopup();
-					}
-				}
-
-				if (!m_SelectionContext.HasComponent<CircleRendererComponent>())
-				{
-					if (ImGui::MenuItem("Circle Renderer"))
-					{
-						m_SelectionContext.AddComponent<CircleRendererComponent>();
-						ImGui::CloseCurrentPopup();
-					}
-				}
-
-				if (!m_SelectionContext.HasComponent<Rigidbody2DComponent>())
-				{
-					if (ImGui::MenuItem("Rigidbody 2D"))
-					{
-						m_SelectionContext.AddComponent<Rigidbody2DComponent>();
-						ImGui::CloseCurrentPopup();
-					}
-				}
-
-				if (!m_SelectionContext.HasComponent<BoxCollider2DComponent>())
-				{
-					if (ImGui::MenuItem("Box Collider 2D"))
-					{
-						m_SelectionContext.AddComponent<BoxCollider2DComponent>();
-						ImGui::CloseCurrentPopup();
-					}
-				}
-
-				if (!m_SelectionContext.HasComponent<CircleCollider2DComponent>())
-				{
-					if (ImGui::MenuItem("Circle Collider 2D"))
-					{
-						m_SelectionContext.AddComponent<CircleCollider2DComponent>();
-						ImGui::CloseCurrentPopup();
-					}
-				}
+			DisplayAddComponentEntry<CameraComponent>("Camera");
+			DisplayAddComponentEntry<SpriteRendererComponent>("Sprite Renderer");
+			DisplayAddComponentEntry<CircleRendererComponent>("Circle Renderer");
+			DisplayAddComponentEntry<Rigidbody2DComponent>("Rigidbody 2D");
+			DisplayAddComponentEntry<BoxCollider2DComponent>("Box Collider 2D");
+			DisplayAddComponentEntry<CircleCollider2DComponent>("Circle Collider 2D");
 
 			ImGui::EndPopup();
 		}
@@ -441,6 +394,18 @@ namespace Hazel {
 			ImGui::DragFloat("Restitution Threshold", &component.RestitutionThreshold, 0.01f, 0.0f);
 		});
 
+	}
+	
+	template<typename T>
+	void SceneHierarchyPanel::DisplayAddComponentEntry(const std::string& entryName) {
+		if (!m_SelectionContext.HasComponent<T>())
+		{
+			if (ImGui::MenuItem(entryName.c_str()))
+			{
+				m_SelectionContext.AddComponent<T>();
+				ImGui::CloseCurrentPopup();
+			}
+		}
 	}
 
 }

--- a/Hazelnut/src/Panels/SceneHierarchyPanel.h
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.h
@@ -19,6 +19,9 @@ namespace Hazel {
 		Entity GetSelectedEntity() const { return m_SelectionContext; }
 		void SetSelectedEntity(Entity entity);
 	private:
+		template<typename T>
+		void DisplayAddComponentEntry(const std::string& entryName);
+	
 		void DrawEntityNode(Entity entity);
 		void DrawComponents(Entity entity);
 	private:


### PR DESCRIPTION
#### Describe the issue
In `SceneHierarchyPanel` , when we press AddComponent button to open the `AddComponent` popup, it displays a list of menu items stating which components could be added to the entity. The code for drawing the menu items with ImGui was a bit repetitive and could be made concise.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Added a template function to draw the `AddComponent` entry.

#### Additional context
Subjected to change depending on Cherno's future changes.