### PR TITLE
Simplify UUID hash specialization

### DIFF
--- a/Hazel/src/Hazel/Core/UUID.h
+++ b/Hazel/src/Hazel/Core/UUID.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <xhash>
-
 namespace Hazel {
 
 	// "UUID" (universally unique identifier) or GUID is (usually) a 128-bit integer
@@ -24,13 +22,14 @@ namespace Hazel {
 }
 
 namespace std {
+	template <typename T> struct hash;
 
 	template <>
 	struct hash<Hazel::UUID>
 	{
 		std::size_t operator()(const Hazel::UUID& uuid) const
 		{
-			return hash<uint64_t>()((uint64_t)uuid);
+			return (uint64_t)uuid;
 		}
 	};
 


### PR DESCRIPTION
Just a quick note I wanted to call out after watching the UUID video which popped up on my feed the other day.

The purpose of `std::hash` is to create a uniformly distributed value from some type. `std::hash<uint64_t>` exists because arbitrary `uint64_t` values aren't inherently uniformly distributed. However, the `uint64_t` generated for `Hazel::UUID` is uniformly distributed. Because of this there is no need to hash it, it can simply be returned.

Additionally including `<xhash>` directly isn't advisable. It is an internal header to the Microsoft STL implementation and therefore is not portable and can even be changed or removed. `std::hash` can just be forward declared anyway so you don't have to include (the very heavy) `<functional>` either.

Last note, which I did not make a change for, is that the `uint64_t` value should be casted to `size_t` when returned. Compiling for 32-bit will cause warning otherwise as it is an implicit narrowing conversion. Although `size_t` is generally the same basic type as `uint64_t` it isn't guaranteed by the standard so a `static_cast` would be appropriate for portability.

I'm glad people are gravitating to your channel for this content, its cool to see someone walking through making a game engine in a way non-engine devs can understand. Dropping these notes here just in case they are helpful for others who pass by.