### PR TITLE
Add missing Save feature

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -234,7 +234,10 @@ namespace Hazel {
 				if (ImGui::MenuItem("Open...", "Ctrl+O"))
 					OpenScene();
 
-				if (ImGui::MenuItem("Save As...", "Ctrl+Shift+S"))
+				if (ImGui::MenuItem("Save", "Ctrl+S", false, m_ActiveScene != nullptr))
+					SaveScene();
+
+				if (ImGui::MenuItem("Save As...", "Ctrl+Shift+S", false, m_ActiveScene != nullptr))
 					SaveSceneAs();
 
 				if (ImGui::MenuItem("Exit")) Application::Get().Close();
@@ -415,8 +418,13 @@ namespace Hazel {
 			}
 			case Key::S:
 			{
-				if (control && shift)
-					SaveSceneAs();
+				if (control)
+				{
+					if (shift)
+						SaveSceneAs();
+					else
+						SaveScene();
+				}
 
 				break;
 			}
@@ -500,16 +508,28 @@ namespace Hazel {
 			m_ActiveScene = m_EditorScene;
 			m_ActiveScene->OnViewportResize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
 			m_SceneHierarchyPanel.SetContext(m_ActiveScene);
+
+			m_ActiveSceneFilePath = path.string();
 		}
+	}
+
+	void EditorLayer::SaveScene()
+	{
+		if (m_ActiveSceneFilePath.empty())
+			SaveSceneAs();
+
+		// Duplicated code! (but at least it works for now)
+		SceneSerializer serializer(m_ActiveScene);
+		serializer.Serialize(m_ActiveSceneFilePath);
 	}
 
 	void EditorLayer::SaveSceneAs()
 	{
-		std::string filepath = FileDialogs::SaveFile("Hazel Scene (*.hazel)\0*.hazel\0");
-		if (!filepath.empty())
+		std::string m_ActiveSceneFilePath = FileDialogs::SaveFile("Hazel Scene (*.hazel)\0*.hazel\0");
+		if (!m_ActiveSceneFilePath.empty())
 		{
 			SceneSerializer serializer(m_ActiveScene);
-			serializer.Serialize(filepath);
+			serializer.Serialize(m_ActiveSceneFilePath);
 		}
 	}
 

--- a/Hazelnut/src/EditorLayer.h
+++ b/Hazelnut/src/EditorLayer.h
@@ -27,6 +27,7 @@ namespace Hazel {
 		void NewScene();
 		void OpenScene();
 		void OpenScene(const std::filesystem::path& path);
+		void SaveScene();
 		void SaveSceneAs();
 
 		void OnScenePlay();
@@ -65,6 +66,8 @@ namespace Hazel {
 		glm::vec4 m_SquareColor = { 0.2f, 0.3f, 0.8f, 1.0f };
 
 		int m_GizmoType = -1;
+
+		std::string m_ActiveSceneFilePath = "";
 
 		enum class SceneState
 		{


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
This PR does not fix any issue.
This PR add the long-missing Save feature (so far we only have Save As...).
Also, `Save` and `Save As...` menu will be disabled if no scene is loaded.

#### PR impact 
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix 
`EditorLayer` now keeps track of active scene's file path. If active scene is a new scene, its file path will be empty.\
When using `File -> Save`, active scene will be saved under this stored file path. If the file path is empty, it will be redirected to `Save As...`.

#### Additional context
`Save` and `Save As...` menu will be disabled if no scene is loaded. Currently Hazelnut doesn't have `Close` menu, or there is no way to 'legally' set active scene to null, but I still add this small feature, hopefully it may be useful in the future when `Close` menu is added.
