### PR TITLE
Fixed crash when playing without an active camera

### DIFF
--- a/Hazelnut/imgui.ini
+++ b/Hazelnut/imgui.ini
@@ -1,6 +1,6 @@
 [Window][DockSpace Demo]
 Pos=0,0
-Size=1600,900
+Size=2560,1387
 Collapsed=0
 
 [Window][Debug##Default]
@@ -10,20 +10,20 @@ Size=400,400
 Collapsed=0
 
 [Window][Settings]
-Pos=1264,465
-Size=336,435
+Pos=2022,710
+Size=538,677
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Viewport]
-Pos=372,69
-Size=890,614
+Pos=595,69
+Size=1425,981
 Collapsed=0
 DockId=0x0000000C,0
 
 [Window][Scene Hierarchy]
 Pos=0,24
-Size=370,435
+Size=593,677
 Collapsed=0
 DockId=0x00000005,0
 
@@ -34,31 +34,31 @@ Size=1421,1027
 Collapsed=0
 
 [Window][Properties]
-Pos=0,461
-Size=370,439
+Pos=0,703
+Size=593,684
 Collapsed=0
 DockId=0x00000006,0
 
 [Window][Stats]
-Pos=1264,24
-Size=336,439
+Pos=2022,24
+Size=538,684
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][Content Browser]
-Pos=372,685
-Size=890,215
+Pos=595,1052
+Size=1425,335
 Collapsed=0
 DockId=0x0000000A,0
 
 [Window][##toolbar]
-Pos=372,24
-Size=890,43
+Pos=595,24
+Size=1425,43
 Collapsed=0
 DockId=0x0000000B,0
 
 [Docking][Data]
-DockSpace         ID=0x3BC79352 Window=0x4647B76E Pos=307,336 Size=1600,876 Split=X Selected=0x995B0CF8
+DockSpace         ID=0x3BC79352 Window=0x4647B76E Pos=0,47 Size=2560,1363 Split=X Selected=0x995B0CF8
   DockNode        ID=0x00000008 Parent=0x3BC79352 SizeRef=1262,876 Split=X
     DockNode      ID=0x00000001 Parent=0x00000008 SizeRef=370,696 Split=Y Selected=0xC89E3217
       DockNode    ID=0x00000005 Parent=0x00000001 SizeRef=370,435 Selected=0x9A68760C

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -595,6 +595,12 @@ namespace Hazel {
 
 	void EditorLayer::OnScenePlay()
 	{
+		if (!m_EditorScene->GetPrimaryCameraEntity())
+		{
+			HZ_WARN("No active camera rendering!");
+			return;
+		}
+
 		m_SceneState = SceneState::Play;
 
 		m_ActiveScene = Scene::Copy(m_EditorScene);


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
When hitting the 'Play' button without any cameras rendering the scene, the application crashes.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
To fix this issue, before playing the scene, a check is made to make sure there is a camera rendering.

#### Additional context
Tested on my machine, should work on all platforms.
