### PR TITLE
EditorCamera should only process events during edit time

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -380,7 +380,10 @@ namespace Hazel {
 	void EditorLayer::OnEvent(Event& e)
 	{
 		m_CameraController.OnEvent(e);
-		m_EditorCamera.OnEvent(e);
+		if (m_SceneState == SceneState::Edit)
+		{
+			m_EditorCamera.OnEvent(e);
+		}
 
 		EventDispatcher dispatcher(e);
 		dispatcher.Dispatch<KeyPressedEvent>(HZ_BIND_EVENT_FN(EditorLayer::OnKeyPressed));


### PR DESCRIPTION
#### Describe the issue
Currently the editor camera is receiving events whilst the game is running, leading to odd behaviour:
1. Open PinkCube scene
2. Scroll up to zoom into the cube
3. Click run
4. Scroll down to zoom out, you won't see any zoom as we're only showing the runtime camera
5. Click stop
6. The editor camera processed the scroll events in the background, when it should be ignoring them

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Only propagate events to editor camera if we are in edit mode.
