### PR TITLE
Sync Hazelnut window title with active scene name

### DIFF
--- a/Hazel/src/Hazel/Core/Window.h
+++ b/Hazel/src/Hazel/Core/Window.h
@@ -39,6 +39,8 @@ namespace Hazel {
 		virtual void SetVSync(bool enabled) = 0;
 		virtual bool IsVSync() const = 0;
 
+		virtual void SetTitle(const std::string& title) = 0;
+
 		virtual void* GetNativeWindow() const = 0;
 
 		static Scope<Window> Create(const WindowProps& props = WindowProps());

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -133,11 +133,6 @@ namespace Hazel {
 		m_Name = name;
 	}
 
-	void Scene::SetName(const std::filesystem::path& filepath)
-	{
-		m_Name = filepath.stem().string();
-	}
-
 	template<typename T>
 	void Scene::OnComponentAdded(Entity entity, T& component)
 	{

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -133,6 +133,11 @@ namespace Hazel {
 		m_Name = name;
 	}
 
+	void Scene::SetName(const std::filesystem::path& filepath)
+	{
+		m_Name = filepath.stem().string();
+	}
+
 	template<typename T>
 	void Scene::OnComponentAdded(Entity entity, T& component)
 	{

--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -128,6 +128,11 @@ namespace Hazel {
 		return {};
 	}
 
+	void Scene::SetName(const std::string& name)
+	{
+		m_Name = name;
+	}
+
 	template<typename T>
 	void Scene::OnComponentAdded(Entity entity, T& component)
 	{

--- a/Hazel/src/Hazel/Scene/Scene.h
+++ b/Hazel/src/Hazel/Scene/Scene.h
@@ -25,6 +25,7 @@ namespace Hazel {
 		Entity GetPrimaryCameraEntity();
 
 		void SetName(const std::string& name);
+		void SetName(const std::filesystem::path& filepath);
 		const std::string& GetName() const { return m_Name; }
 	private:
 		template<typename T>

--- a/Hazel/src/Hazel/Scene/Scene.h
+++ b/Hazel/src/Hazel/Scene/Scene.h
@@ -25,7 +25,6 @@ namespace Hazel {
 		Entity GetPrimaryCameraEntity();
 
 		void SetName(const std::string& name);
-		void SetName(const std::filesystem::path& filepath);
 		const std::string& GetName() const { return m_Name; }
 	private:
 		template<typename T>

--- a/Hazel/src/Hazel/Scene/Scene.h
+++ b/Hazel/src/Hazel/Scene/Scene.h
@@ -23,12 +23,17 @@ namespace Hazel {
 		void OnViewportResize(uint32_t width, uint32_t height);
 
 		Entity GetPrimaryCameraEntity();
+
+		void SetName(const std::string& name);
+		const std::string& GetName() const { return m_Name; }
 	private:
 		template<typename T>
 		void OnComponentAdded(Entity entity, T& component);
 	private:
 		entt::registry m_Registry;
 		uint32_t m_ViewportWidth = 0, m_ViewportHeight = 0;
+
+		std::string m_Name = "Untitled";
 
 		friend class Entity;
 		friend class SceneSerializer;

--- a/Hazel/src/Hazel/Scene/SceneSerializer.cpp
+++ b/Hazel/src/Hazel/Scene/SceneSerializer.cpp
@@ -252,6 +252,8 @@ namespace Hazel {
 			}
 		}
 
+		m_Scene->SetName(std::filesystem::path(filepath).filename().string());
+
 		return true;
 	}
 

--- a/Hazel/src/Hazel/Scene/SceneSerializer.cpp
+++ b/Hazel/src/Hazel/Scene/SceneSerializer.cpp
@@ -252,7 +252,7 @@ namespace Hazel {
 			}
 		}
 
-		m_Scene->SetName(std::filesystem::path(filepath).filename().string());
+		m_Scene->SetName(std::filesystem::path(filepath));
 
 		return true;
 	}

--- a/Hazel/src/Hazel/Scene/SceneSerializer.cpp
+++ b/Hazel/src/Hazel/Scene/SceneSerializer.cpp
@@ -156,7 +156,7 @@ namespace Hazel {
 	{
 		YAML::Emitter out;
 		out << YAML::BeginMap;
-		out << YAML::Key << "Scene" << YAML::Value << "Untitled";
+		out << YAML::Key << "Scene" << YAML::Value << m_Scene->GetName();
 		out << YAML::Key << "Entities" << YAML::Value << YAML::BeginSeq;
 		m_Scene->m_Registry.each([&](auto entityID)
 		{
@@ -196,6 +196,7 @@ namespace Hazel {
 
 		std::string sceneName = data["Scene"].as<std::string>();
 		HZ_CORE_TRACE("Deserializing scene '{0}'", sceneName);
+		m_Scene->SetName(sceneName);
 
 		auto entities = data["Entities"];
 		if (entities)
@@ -251,8 +252,6 @@ namespace Hazel {
 				}
 			}
 		}
-
-		m_Scene->SetName(std::filesystem::path(filepath));
 
 		return true;
 	}

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -197,4 +197,9 @@ namespace Hazel {
 		return m_Data.VSync;
 	}
 
+	void WindowsWindow::SetTitle(const std::string& title)
+	{
+		glfwSetWindowTitle(m_Window, title.c_str());
+	}
+
 }

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -199,7 +199,7 @@ namespace Hazel {
 
 	void WindowsWindow::SetTitle(const std::string& title)
 	{
+		m_Data.Title = title;
 		glfwSetWindowTitle(m_Window, title.c_str());
 	}
-
 }

--- a/Hazel/src/Platform/Windows/WindowsWindow.h
+++ b/Hazel/src/Platform/Windows/WindowsWindow.h
@@ -23,6 +23,8 @@ namespace Hazel {
 		void SetVSync(bool enabled) override;
 		bool IsVSync() const override;
 
+		void SetTitle(const std::string& title) override;
+
 		virtual void* GetNativeWindow() const { return m_Window; }
 	private:
 		virtual void Init(const WindowProps& props);

--- a/Hazelnut/assets/scenes/3DExample.hazel
+++ b/Hazelnut/assets/scenes/3DExample.hazel
@@ -1,4 +1,4 @@
-Scene: Untitled
+Scene: 3DExample
 Entities:
   - Entity: 12837192831273
     TagComponent:

--- a/Hazelnut/assets/scenes/Example.hazel
+++ b/Hazelnut/assets/scenes/Example.hazel
@@ -1,4 +1,4 @@
-Scene: Untitled
+Scene: Example
 Entities:
   - Entity: 12837192831273
     TagComponent:

--- a/Hazelnut/assets/scenes/PinkCube.hazel
+++ b/Hazelnut/assets/scenes/PinkCube.hazel
@@ -1,4 +1,4 @@
-Scene: Untitled
+Scene: PinkCube
 Entities:
   - Entity: 12837192831273
     TagComponent:

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -498,7 +498,7 @@ namespace Hazel {
 		{
 			SceneSerializer serializer(m_ActiveScene);
 			serializer.Serialize(filepath);
-			m_ActiveScene->SetName(std::filesystem::path(filepath).filename().string());
+			m_ActiveScene->SetName(std::filesystem::path(filepath));
 			SetWindowTitleFromActiveScene();
 		}
 	}

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -25,6 +25,8 @@ namespace Hazel {
 	{
 		HZ_PROFILE_FUNCTION();
 
+		Application::Get().GetWindow().SetTitle("Test");
+
 		m_CheckerboardTexture = Texture2D::Create("assets/textures/Checkerboard.png");
 		m_IconPlay = Texture2D::Create("Resources/Icons/PlayButton.png");
 		m_IconStop = Texture2D::Create("Resources/Icons/StopButton.png");

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -499,6 +499,7 @@ namespace Hazel {
 		{
 			SceneSerializer serializer(m_ActiveScene);
 			serializer.Serialize(filepath);
+			m_ActiveScene->SetName(std::filesystem::path(filepath).filename().string());
 		}
 	}
 

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -498,8 +498,6 @@ namespace Hazel {
 		{
 			SceneSerializer serializer(m_ActiveScene);
 			serializer.Serialize(filepath);
-			m_ActiveScene->SetName(std::filesystem::path(filepath));
-			SetWindowTitleFromActiveScene();
 		}
 	}
 

--- a/Hazelnut/src/EditorLayer.h
+++ b/Hazelnut/src/EditorLayer.h
@@ -32,6 +32,9 @@ namespace Hazel {
 		void OnScenePlay();
 		void OnSceneStop();
 
+		void SetActiveScene(const Ref<Scene>& activeScene);
+		void SetWindowTitleFromActiveScene();
+
 		// UI Panels
 		void UI_Toolbar();
 	private:

--- a/Hazelnut/src/EditorLayer.h
+++ b/Hazelnut/src/EditorLayer.h
@@ -26,14 +26,15 @@ namespace Hazel {
 
 		void NewScene();
 		void OpenScene();
-		void OpenScene(const std::filesystem::path& path);
+		bool OpenScene(const std::filesystem::path& path);
 		void SaveSceneAs();
 
 		void OnScenePlay();
 		void OnSceneStop();
 
 		void SetActiveScene(const Ref<Scene>& activeScene);
-		void SetWindowTitleFromActiveScene();
+		void SetEditorScenePath(const std::filesystem::path& path);
+		void SyncWindowTitle();
 
 		// UI Panels
 		void UI_Toolbar();
@@ -46,6 +47,8 @@ namespace Hazel {
 		Ref<Framebuffer> m_Framebuffer;
 
 		Ref<Scene> m_ActiveScene;
+		std::filesystem::path m_EditorScenePath;
+
 		Entity m_SquareEntity;
 		Entity m_CameraEntity;
 		Entity m_SecondCamera;


### PR DESCRIPTION
When opening or saving a scene, we now sync the window title with both the scene name and the filepath the scene is saved in.

- Exposed `Window::SetTitle()` which callls `glfwSetWindowTitle`
- Updated SceneSerializer to read/write an actual scene name instead of hardcoded. We store this in `Scene::m_Name`. It can't be changed in the UI yet, only the .hazel scene file. Also updated the demo scenes to have a correct title
- EditorLayer tracks `m_EditorScenePath` very similarly to how it was added in 816baa3e055f5b8010ebc514a775e2928e032a7f in physics branch
- Consolidated changing which scene is active into a method `EditorLayer::SetActiveScene()` 
- Changed `EditorLayer::OnAttach()` to use `NewScene()` and `OpenScene()` methods. This did introduced an awkward issue with `m_ViewportSize`, as `SetActiveScene()` tries to resize the viewport in the active scene, but during `OnAttach()` the viewport size is 0, which leads to the resize methods asserting. The solution taken here was to set the viewport size to a valid value based on how the framebuffer was created before doing new/open scene, then when we go to update/render, it'll be set to the correct value based on how the viewport actually looks.


 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None
