### PR TITLE
Fixed use of "std::filesystem::relative" in Content Browser main loop

### DIFF
--- a/Hazelnut/src/Panels/ContentBrowserPanel.cpp
+++ b/Hazelnut/src/Panels/ContentBrowserPanel.cpp
@@ -41,8 +41,7 @@ namespace Hazel {
 		for (auto& directoryEntry : std::filesystem::directory_iterator(m_CurrentDirectory))
 		{
 			const auto& path = directoryEntry.path();
-			auto relativePath = std::filesystem::relative(path, g_AssetPath);
-			std::string filenameString = relativePath.filename().string();
+			std::string filenameString = path.filename().string();
 			
 			ImGui::PushID(filenameString.c_str());
 			Ref<Texture2D> icon = directoryEntry.is_directory() ? m_DirectoryIcon : m_FileIcon;
@@ -51,6 +50,7 @@ namespace Hazel {
 
 			if (ImGui::BeginDragDropSource())
 			{
+				auto relativePath = std::filesystem::relative(path, g_AssetPath);
 				const wchar_t* itemPath = relativePath.c_str();
 				ImGui::SetDragDropPayload("CONTENT_BROWSER_ITEM", itemPath, (wcslen(itemPath) + 1) * sizeof(wchar_t));
 				ImGui::EndDragDropSource();


### PR DESCRIPTION
#### Describe the issue
The use of "std::filesystem::relative" in the main loop of the content browser results in huge slow downs (visible when not limiting VSYNC).

#### Proposed fix 
Using the path to get the filenamestring, and only obtaining the relative path when doing the actual drag and drop. 
Discovered that on my own engine, and shared it in the Cherno discord to confirm it didn't only happened to me.
