### PR TITLE
Implemented SetupPremake.py to Download the Latest Premake Release

### DIFF
--- a/scripts/SetupPremake.py
+++ b/scripts/SetupPremake.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import Utils
 
 class PremakeConfiguration:
-    premakeVersion = "5.0.0-alpha16"
+    premakeVersion = "5.0.0-beta1"
     premakeZipUrls = f"https://github.com/premake/premake-core/releases/download/v{premakeVersion}/premake-{premakeVersion}-windows.zip"
     premakeLicenseUrl = "https://raw.githubusercontent.com/premake/premake-core/master/LICENSE.txt"
     premakeDirectory = "./vendor/premake/bin"

--- a/scripts/SetupPremake.py
+++ b/scripts/SetupPremake.py
@@ -1,11 +1,25 @@
 import sys
 import os
+import requests
 from pathlib import Path
 
 import Utils
 
+def GetLatestPremakeVersion():
+    LATEST_ENTRY = 0
+    TAG_FIELD = "tag_name"
+    url = "https://api.github.com/repos/premake/premake-core/releases"
+    headers = {
+        'Accept': 'application/vnd.github.v3+json'
+    }
+    response = requests.request("GET", url, headers = headers)
+    if (response.status_code != 200) :
+        return "5.0.0-beta1" # default if lookup fails
+    return response.json()[LATEST_ENTRY][TAG_FIELD][1:] # Strip 'v' character out of tag name. Ex: v5.0.0-beta1 -> 5.0.0-beta1
+
 class PremakeConfiguration:
-    premakeVersion = "5.0.0-beta1"
+
+    premakeVersion = GetLatestPremakeVersion()
     premakeZipUrls = f"https://github.com/premake/premake-core/releases/download/v{premakeVersion}/premake-{premakeVersion}-windows.zip"
     premakeLicenseUrl = "https://raw.githubusercontent.com/premake/premake-core/master/LICENSE.txt"
     premakeDirectory = "./vendor/premake/bin"


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)

Closes #545

#### PR impact 
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       |  Closes #545
Other PRs this solves    | None

#### Proposed fix 

Implemented SetupPremake.py to download ~`5.0.0-beta1`~ the latest version of premake instead of using `5.0.0-alpha16`. If the lookup fails, it will default to `5.0.0-beta1`.

In addition to being more stable, the beta adds support for `Visual Studio 2022` should people wish to use it. This allows me to natively build projects for `VS22` by manually editing `Win-GenProjects.bat`. I have not edited `Win-GenProjects.bat` to avoid breaking the build for other devs who are not using `VS22`, but downloading the beta rather than the alpha gives everyone the option to use `VS22` natively, and also generally adds stability over using the alpha.

#### Additional context

I tested this solution on Windows 10 Home 64-bit, it appears to download premake correctly and I was able to build and run the engine.

[Premake 5.0.0-beta1 Release and Changelog](https://github.com/premake/premake-core/releases/tag/v5.0.0-beta1)