### PR TITLE
Hazelnut and Sandbox builds release build without console

### DIFF
--- a/Hazelnut/premake5.lua
+++ b/Hazelnut/premake5.lua
@@ -45,6 +45,8 @@ project "Hazelnut"
 		defines "HZ_RELEASE"
 		runtime "Release"
 		optimize "on"
+		kind "WindowedApp"
+		entrypoint "mainCRTStartup"
 
 	filter "configurations:Dist"
 		defines "HZ_DIST"

--- a/Sandbox/premake5.lua
+++ b/Sandbox/premake5.lua
@@ -44,6 +44,8 @@ project "Sandbox"
 		defines "HZ_RELEASE"
 		runtime "Release"
 		optimize "on"
+		kind "WindowedApp"
+		entrypoint "mainCRTStartup"
 
 	filter "configurations:Dist"
 		defines "HZ_DIST"


### PR DESCRIPTION
#### Describe the issue
Release builds were building with the console launching.

#### Proposed fix
In the Sandbox and Hazelnut premake files a kind and an entrypoint were defined in the release filter.

#### Additional context
Only has been tested on Windows 11 but when I ran the release builds for both Sandbox and Hazelnut the desired outcome was obtained.