### PR TITLE
Update the old texture comparison behavior

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLTexture.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLTexture.h
@@ -25,7 +25,7 @@ namespace Hazel {
 
 		virtual bool operator==(const Texture& other) const override
 		{
-			return m_RendererID == ((OpenGLTexture2D&)other).m_RendererID;
+			return m_RendererID == other.GetRendererID();
 		}
 	private:
 		std::string m_Path;


### PR DESCRIPTION
Replaced unnecessary casting with GetRendererID
