### PR TITLE
Fixed crash when opening a new scene during a physics simulation

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -531,6 +531,9 @@ namespace Hazel {
 
 	void EditorLayer::NewScene()
 	{
+		if (m_SceneState != SceneState::Edit)
+			OnSceneStop();
+
 		m_ActiveScene = CreateRef<Scene>();
 		m_ActiveScene->OnViewportResize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
 		m_SceneHierarchyPanel.SetContext(m_ActiveScene);


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
A clear and concise description of what the issue is. Explain the difference between the expected and the current behavior.
A screenshot or copy of the error could be helpful as well.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | #484 
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Calling OnSceneStop if SceneState is not Edit before creating a new scene.

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.
