### PR TITLE
Implemented platform agnostic GetTime()

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -6,8 +6,7 @@
 #include "Hazel/Renderer/Renderer.h"
 
 #include "Hazel/Core/Input.h"
-
-#include <GLFW/glfw3.h>
+#include "Hazel/Utils/PlatformUtils.h"
 
 namespace Hazel {
 
@@ -81,7 +80,7 @@ namespace Hazel {
 		{
 			HZ_PROFILE_SCOPE("RunLoop");
 
-			float time = (float)glfwGetTime();
+			float time = Time::GetTime();
 			Timestep timestep = time - m_LastFrameTime;
 			m_LastFrameTime = time;
 

--- a/Hazel/src/Hazel/Utils/PlatformUtils.h
+++ b/Hazel/src/Hazel/Utils/PlatformUtils.h
@@ -12,4 +12,10 @@ namespace Hazel {
 		static std::string SaveFile(const char* filter);
 	};
 
+	class Time
+	{
+	public:
+		static float GetTime();
+	};
+
 }

--- a/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Hazel/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -10,6 +10,12 @@
 
 namespace Hazel {
 
+	float Time::GetTime()
+	{
+		return glfwGetTime();
+	}
+
+
 	std::string FileDialogs::OpenFile(const char* filter)
 	{
 		OPENFILENAMEA ofn;


### PR DESCRIPTION
Provides a way to just import platform utils and get time in seconds by calling Time::GetTime(), without hard coding the glfw way of obtaining it.

#### Describe the issue (if no issue has been made)
Watching the episode named TIMESTEPS and DELTA TIME from the engine series I realized that the platform agnostic way of getting the time to calculate the delta time was never implemented. It still imported and used glfw in Application.cpp

#### PR impact
None (didn't find any, didn't open any)

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Added static class Time with only one method named GetTime() into file Hazel/Utils/PlatformUtils.h. 
Transferred the windows implementation of it (glfwGetTime()) that was used in Application.cpp  into Time::GetTIme() inside the file Platform/Windows/WindowsUtils.cpp. 
In Application.cpp the glfw import was deleted and replaced with the import for PlatformUtils.h. In the method OnUpdate, instead of calling directly glfwGetTime(), used Time::GetTime().

#### Additional context
- [x] Tested on Windows
