### PR TITLE
Update SetupVulkan.py to fix broken download link for VulkanSDK

### DIFF
--- a/scripts/SetupVulkan.py
+++ b/scripts/SetupVulkan.py
@@ -51,7 +51,7 @@ class VulkanConfiguration:
             permissionGranted = (reply == 'y')
 
         vulkanInstallURL = f"https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe"
-        vulkanPath = f"{cls.vulkanDirectory}/VulkanSDK-Installer.exe"
+        vulkanPath = f"{cls.vulkanDirectory}/vulkan-sdk.exe"
         print("Downloading {0:s} to {1:s}".format(vulkanInstallURL, vulkanPath))
         Utils.DownloadFile(vulkanInstallURL, vulkanPath)
         print("Running Vulkan SDK installer...")

--- a/scripts/SetupVulkan.py
+++ b/scripts/SetupVulkan.py
@@ -50,8 +50,8 @@ class VulkanConfiguration:
                 return
             permissionGranted = (reply == 'y')
 
-        vulkanInstallURL = f"https://sdk.lunarg.com/sdk/download/{cls.requiredVulkanVersion}/windows/VulkanSDK-{cls.requiredVulkanVersion}-Installer.exe"
-        vulkanPath = f"{cls.vulkanDirectory}/VulkanSDK-{cls.requiredVulkanVersion}-Installer.exe"
+        vulkanInstallURL = f"https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe"
+        vulkanPath = f"{cls.vulkanDirectory}/VulkanSDK-Installer.exe"
         print("Downloading {0:s} to {1:s}".format(vulkanInstallURL, vulkanPath))
         Utils.DownloadFile(vulkanInstallURL, vulkanPath)
         print("Running Vulkan SDK installer...")


### PR DESCRIPTION
Now always downloads the latest VulkanSDK (official link)

#### Describe the issue (if no issue has been made)
Latest commit to this file (https://github.com/TheCherno/Hazel/commit/b7ee3e9c8bc11a5e516358b59867eca8709f9455) has broken the download link for VulkanSDK. Since the required vulkansdk version is now "1.3.", the download link will resolve to "https://sdk.lunarg.com/sdk/download/1.3./windows/VulkanSDK-1.3.-Installer.exe", which is a broken link.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_

Issues fixed: #558 

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_

This pull request solves this problem by acquiring the latest VulkanSDK version, which is an official link from the website. The download link is: https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe

The vulkansdk version will now not be used in the filename of the installer. You can still get it when using the installer, since this is in the default path.

#### Additional context
Tested on the latest version of Hazel master branch.
