### PR TITLE
Scene hierarchy won't show "Create Empty Entity" menu!

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -36,6 +36,7 @@ namespace Hazel {
 
 		m_EditorScene = CreateRef<Scene>();
 		m_ActiveScene = m_EditorScene;
+		m_SceneHierarchyPanel.SetContext(m_ActiveScene);
 
 		auto commandLineArgs = Application::Get().GetCommandLineArgs();
 		if (commandLineArgs.Count > 1)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Currently with the code used in Hazel 2D, and when launching Hazel 2D,
you can't get the "Create Empty Entity" to pop up.

This bug is ONLY happening when you haven't loaded a scene OR created a new scene!

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute])
By adding:
`m_SceneHierarchyPanel.SetContext(m_ActiveScene);`
after `m_ActiveScene = m_EditorScene;` inside `OnAttach()` in `EditorLayer.cpp`
right-clicking to display the menu works again!

Steps to reproduce the bug:
1: open up Hazel 2D.
2: Move mouse cursor over to the Scene hierarchy.
3: Right-click and see that the "Create Empty Entity" won't pop up.