### PR TITLE
Fixed issues with `EditorLayer::NewScene()`

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -569,6 +569,8 @@ namespace Hazel {
 		m_EditorScene = CreateRef<Scene>();
 		m_EditorScene->OnViewportResize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
 		m_SceneHierarchyPanel.SetContext(m_EditorScene);
+
+		m_ActiveScene = m_EditorScene;
 		
 		m_EditorScenePath = std::filesystem::path();
 	}

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -563,9 +563,12 @@ namespace Hazel {
 
 	void EditorLayer::NewScene()
 	{
-		m_ActiveScene = CreateRef<Scene>();
-		m_ActiveScene->OnViewportResize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
-		m_SceneHierarchyPanel.SetContext(m_ActiveScene);
+		if (m_SceneState != SceneState::Edit)
+			OnSceneStop();
+
+		m_EditorScene = CreateRef<Scene>();
+		m_EditorScene->OnViewportResize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
+		m_SceneHierarchyPanel.SetContext(m_EditorScene);
 		
 		m_EditorScenePath = std::filesystem::path();
 	}


### PR DESCRIPTION
#### Describe the issue(s)
* When you try to create a new empty scene while playing/simulating, Hazelnut crashes.
* When you open a new (empty) scene (without having loaded a scene file before), then modify and play the scene, an empty `m_EditorScene` is copied to `m_ActiveScene`, causing loss off all progress.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
* Stop the scene if it is currently playing/simulating.
* Create a new `m_EditorScene` instead of `m_ActiveScene` in `NewScene()`.

