### PR TITLE
Add selected entity outline rendering

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -558,6 +558,14 @@ namespace Hazel {
 			}
 		}
 
+		// Draw selected entity outline 
+		if (Entity selectedEntity = m_SceneHierarchyPanel.GetSelectedEntity()) {
+			TransformComponent transform = selectedEntity.GetComponent<TransformComponent>();
+
+			//Red
+			Renderer2D::DrawRect(transform.GetTransform(), glm::vec4(1, 0, 0, 1));
+		}
+
 		Renderer2D::EndScene();
 	}
 


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
This PR aims to implement an outline to selected entities to help users differentiate between selected vs. nonselected entities.
![image](https://user-images.githubusercontent.com/29360565/177018845-ab009d7a-def2-4b24-83d2-84649b6ff393.png)


#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | This PR implements a task from the roadmap
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
This is a simple addition that uses already existing APIs to render a red quad around selected entities:
`EditorLayer::OnOverlayRender()`
```cpp
// Draw selected entity outline 
if (Entity selectedEntity = m_SceneHierarchyPanel.GetSelectedEntity()) {
	TransformComponent transform = selectedEntity.GetComponent<TransformComponent>();

	//Red
	Renderer2D::DrawRect(transform.GetTransform(), glm::vec4(1, 0, 0, 1));
}
```

#### Additional context
Tested on Windows 10 Build 19043
