### PR TITLE
Don't allow using Gizmos while holding left alt

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -256,7 +256,7 @@ namespace Hazel {
 
 		// Gizmos
 		Entity selectedEntity = m_SceneHierarchyPanel.GetSelectedEntity();
-		if (selectedEntity && m_GizmoType != -1)
+		if (selectedEntity && m_GizmoType != -1 && !Input::IsKeyPressed(Key::LeftAlt))
 		{
 			ImGuizmo::SetOrthographic(false);
 			ImGuizmo::SetDrawlist();


### PR DESCRIPTION
#### Issue description
When gizmos are used while holding left alt, gizmos and scene navigation occurs simultaneously which is not ideal and should not happen.

#### Proposed fix
Don't let the user operate the gizmo while holding left alt.