### PR TITLE
Added image icons in content browser

### DIFF
--- a/Hazelnut/src/Panels/ContentBrowserPanel.cpp
+++ b/Hazelnut/src/Panels/ContentBrowserPanel.cpp
@@ -27,6 +27,15 @@ namespace Hazel {
 			}
 		}
 
+		// Make sure cached texture icons exist, if they dont remove them from cache
+		for (auto it = m_ImageIcons.cbegin(), next_it = it; it != m_ImageIcons.cend(); it = next_it)
+		{
+			++next_it;
+
+			if (!std::filesystem::exists((*it).first))
+				m_ImageIcons.erase(it);
+		}
+
 		static float padding = 16.0f;
 		static float thumbnailSize = 128.0f;
 		float cellSize = thumbnailSize + padding;
@@ -44,7 +53,16 @@ namespace Hazel {
 			std::string filenameString = path.filename().string();
 			
 			ImGui::PushID(filenameString.c_str());
+
 			Ref<Texture2D> icon = directoryEntry.is_directory() ? m_DirectoryIcon : m_FileIcon;
+			if (path.extension().string() == ".png")
+			{
+				if (m_ImageIcons.find(path.string()) == m_ImageIcons.end())
+					m_ImageIcons[path.string()] = Texture2D::Create(path.string());
+
+				icon = m_ImageIcons[path.string()];
+			}
+
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
 			ImGui::ImageButton((ImTextureID)icon->GetRendererID(), { thumbnailSize, thumbnailSize }, { 0, 1 }, { 1, 0 });
 

--- a/Hazelnut/src/Panels/ContentBrowserPanel.h
+++ b/Hazelnut/src/Panels/ContentBrowserPanel.h
@@ -3,6 +3,7 @@
 #include "Hazel/Renderer/Texture.h"
 
 #include <filesystem>
+#include <unordered_map>
 
 namespace Hazel {
 
@@ -17,6 +18,7 @@ namespace Hazel {
 		
 		Ref<Texture2D> m_DirectoryIcon;
 		Ref<Texture2D> m_FileIcon;
+		std::unordered_map<std::string, Ref<Texture2D>> m_ImageIcons;
 	};
 
 }


### PR DESCRIPTION
Currently textures/images in the Content Browser panel display the default file icon, as a QOL feature I've changed it to use the image itself.

![image](https://user-images.githubusercontent.com/24930433/177559905-a981f2d4-85ed-43ca-a84d-cab55e3542f1.png)

To avoid having to recreate the texture every frame I add it to a cache (unordered map of file path string to texture). An issue with this approach is that if the file is deleted it wouldn't be removed from the cache so I added the code below to remove the textures from cache if the file no longer exists.
```
for (auto it = m_ImageIcons.cbegin(), next_it = it; it != m_ImageIcons.cend(); it = next_it)
{
	++next_it;

	if (!std::filesystem::exists((*it).first))
		m_ImageIcons.erase(it);
}
```
Unfortunately the for loop has to be written in this way since a normal `auto [key, val]` for loop breaks when you try to remove a key while iterating it.
