### PR TITLE
Added function to convert parameter pack to void**

### DIFF
--- a/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
+++ b/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
@@ -118,21 +118,6 @@ namespace Hazel {
 				return function(argv, static_cast<int>(argc));
 			}
 		}
-
-		/*
-			Example of use:
-
-				MonoObject* returnValue;
-				Utils::WrapArgs([=](void** argv, int argc) {
-					MonoMethod* method = s_Data->EntityClass.GetMethod("PrintInts", argc);
-					return s_Data->EntityClass.InvokeMethod(instance, method, argv);
-				}, returnValue, 5, 508);
-
-			Here instance is presumed to be captured by value from the same scope the WrapArgs function is in.
-			The WrapArgs cannot deduce the return type of the lambda function to use as its own return type, so the return value is passed back as the 2nd parameter.
-			The remaining paramters are the parameters wished to be packed into a void* array. They are packed inside WrapArgs and passed as parameters to the lambda function.
-		*/ 
-
 	}
 
 	struct ScriptEngineData
@@ -186,11 +171,7 @@ namespace Hazel {
 		MonoString* monoString = mono_string_new(s_Data->AppDomain, "Hello World from C++!");
 		MonoMethod* printCustomMessageFunc = s_Data->EntityClass.GetMethod("PrintCustomMessage", 1);
 		void* stringParam = monoString;
-
-		MonoObject* result = Utils::WrapArgs<MonoObject>([=](void** argv, int argc)
-			{
-				return s_Data->EntityClass.InvokeMethod(instance, printCustomMessageFunc, argv);
-			}, result, monoString);
+		s_Data->EntityClass.InvokeMethod(instance, printCustomMessageFunc, &stringParam);
 
 		HZ_CORE_ASSERT(false);
 	}


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
It would be more convenient to be able to use a parameter pack for mono method parameters than to have to always manually put parameters in a void* array. See #570 for more details.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Resolves #570
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
I have added a function to the Utils namespace of ScriptEngine.cpp with the signature 

```
template<typename T, typename Func, typename... Args>
static T* WrapArgs(Func function, Args&&... args)
```

The way to use this function is to pass a lambda as the first argument which wraps the function you intend to use that requires `void**` parameters. The lambda itself will have parameters of `(void** argv, int argc)` to be used with the intended function. The final arguments are a parameter pack which will gets packed into a correctly sized void* array and passed as a paremeter to the lambda. The function returns the result of the lambda, and the type of the return value cannot be deduced automatically so must be passed as template parameter to the function.

Example of use:

```
const char* methodName = "PrintInts";

MonoObject* returnValue = Utils::WrapArgs<MonoObject>([=](void** argv, int argc) {
    MonoMethod* method = s_Data->EntityClass.GetMethod(methodName, argc);
    return s_Data->EntityClass.InvokeMethod(instance, method, argv);
}, returnValue, 5, 508);

// instance is assumed to already exist here.
```

I've also added a templated struct to check whether a parameter type in the parameter pack is a pointer or not, so the correct conversion to a void* can be made.

#### Additional context
Could potentially drop the check to see if `sizeof...(Args)` is zero and just mandate that WrapArgs only be used with a non-empty parameter pack (as it doesn't really make sense to use the function with an empty parameter pack anyway). It was only originally required as `void* argv[argc] = { nullptr };` does not compile with `argc == 0`.

I have tested this compiles by actually using the templated function, but have removed from the main ScriptEngine code to keep as it was previously
