### PR TITLE
ScriptEngine unloading domain during shutdown.

### DIFF
--- a/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
+++ b/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
@@ -163,7 +163,7 @@ namespace Hazel {
 	void ScriptEngine::ShutdownMono()
 	{
 		mono_domain_set(mono_get_root_domain(), false);
-		
+
 		mono_domain_unload(s_Data->AppDomain);
 		s_Data->AppDomain = nullptr;
 

--- a/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
+++ b/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
@@ -162,12 +162,12 @@ namespace Hazel {
 
 	void ScriptEngine::ShutdownMono()
 	{
-		// NOTE(Yan): mono is a little confusing to shutdown, so maybe come back to this
-
-		// mono_domain_unload(s_Data->AppDomain);
+		mono_domain_set(mono_get_root_domain(), false);
+		
+		mono_domain_unload(s_Data->AppDomain);
 		s_Data->AppDomain = nullptr;
 
-		// mono_jit_cleanup(s_Data->RootDomain);
+		mono_jit_cleanup(s_Data->RootDomain);
 		s_Data->RootDomain = nullptr;
 	}
 

--- a/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
+++ b/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
@@ -162,7 +162,7 @@ namespace Hazel {
 
 	void ScriptEngine::ShutdownMono()
 	{
-		mono_domain_set(mono_get_root_domain(), false);
+		mono_domain_set(s_Data->RootDomain, false);
 
 		mono_domain_unload(s_Data->AppDomain);
 		s_Data->AppDomain = nullptr;


### PR DESCRIPTION
In order to properly unload a MonoDomain, a different one has to be set. 
Since we are doing a clean up then we have to set it to the root domain.