### PR TITLE
Fixes early crash in RenderCommand.cpp (#574)

### DIFF
--- a/Hazel/src/Hazel/Renderer/RenderCommand.cpp
+++ b/Hazel/src/Hazel/Renderer/RenderCommand.cpp
@@ -3,6 +3,6 @@
 
 namespace Hazel {
 
-	Scope<RendererAPI> RenderCommand::s_RendererAPI = RendererAPI::Create();
+	Scope<RendererAPI> RenderCommand::s_RendererAPI = nullptr;
 
 }

--- a/Hazel/src/Hazel/Renderer/RenderCommand.h
+++ b/Hazel/src/Hazel/Renderer/RenderCommand.h
@@ -9,6 +9,7 @@ namespace Hazel {
 	public:
 		static void Init()
 		{
+			s_RendererAPI = RendererAPI::Create();
 			s_RendererAPI->Init();
 		}
 


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
RendererAPI creation in `RenderCommand.cpp` will crash *if* we try to log something in `RendererAPI::Create()` function (See #574).

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | Fix #574 

#### Proposed fix
Instead of initializing RendererAPI with Create() function, we first initialize it with `nullptr`, then we actually create it in `RenderCommand::Init()` when Hazel's Log system is available.

#### Additional context
`static`s should not be initialized by calling the program's other system, since that system may not be available at that point.
In this situation, a call to `RendererAPI::Create()` was made during the (`static`) initialization phase, which may cause trouble if that function continues to call to other not yet available system.
