### PR TITLE
Fixed imgui windows not updating if the application window is minimized

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -97,16 +97,16 @@ namespace Hazel {
 					for (Layer* layer : m_LayerStack)
 						layer->OnUpdate(timestep);
 				}
-
-				m_ImGuiLayer->Begin();
-				{
-					HZ_PROFILE_SCOPE("LayerStack OnImGuiRender");
-
-					for (Layer* layer : m_LayerStack)
-						layer->OnImGuiRender();
-				}
-				m_ImGuiLayer->End();
 			}
+
+			m_ImGuiLayer->Begin();
+			{
+				HZ_PROFILE_SCOPE("LayerStack OnImGuiRender");
+
+				for(Layer* layer : m_LayerStack)
+					layer->OnImGuiRender();
+			}
+			m_ImGuiLayer->End();
 
 			m_Window->OnUpdate();
 		}


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
ImGui windows aren't updating if the application window is minimized.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Instead of only calling OnImGuiRender when the window isn't minimized, we call it always.

#### Additional context

