### PR TITLE
Add type mapping for System.SByte

### DIFF
--- a/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
+++ b/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
@@ -16,6 +16,7 @@ namespace Hazel {
 		{ "System.Double", ScriptFieldType::Double },
 		{ "System.Boolean", ScriptFieldType::Bool },
 		{ "System.Char", ScriptFieldType::Char },
+		{ "System.SByte", ScriptFieldType::SByte },
 		{ "System.Int16", ScriptFieldType::Short },
 		{ "System.Int32", ScriptFieldType::Int },
 		{ "System.Int64", ScriptFieldType::Long },
@@ -127,11 +128,11 @@ namespace Hazel {
 				case ScriptFieldType::Double:  return "Double";
 				case ScriptFieldType::Bool:    return "Bool";
 				case ScriptFieldType::Char:    return "Char";
-				case ScriptFieldType::Byte:    return "Byte";
+				case ScriptFieldType::SByte:   return "SByte";
 				case ScriptFieldType::Short:   return "Short";
 				case ScriptFieldType::Int:     return "Int";
 				case ScriptFieldType::Long:    return "Long";
-				case ScriptFieldType::UByte:   return "UByte";
+				case ScriptFieldType::Byte:    return "Byte";
 				case ScriptFieldType::UShort:  return "UShort";
 				case ScriptFieldType::UInt:    return "UInt";
 				case ScriptFieldType::ULong:   return "ULong";


### PR DESCRIPTION
Watched the stream and noticed this was missing.
Not sure how strongly we feel about the UByte naming. Decided to rename it but feel free to change it back.

Also, SByte is not CLS-compliant but I'm not sure if that matters here since I guess this is just to map type names.
https://docs.microsoft.com/en-us/dotnet/api/system.sbyte?view=net-6.0