### PR TITLE
Sets focus to the entity's tag text field after a double-click on it …

### DIFF
--- a/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
@@ -18,6 +18,7 @@
 namespace Hazel {
 
 	extern const std::filesystem::path g_AssetPath;
+	static bool g_DoubleClick = false;
 
 	SceneHierarchyPanel::SceneHierarchyPanel(const Ref<Scene>& context)
 	{
@@ -81,6 +82,9 @@ namespace Hazel {
 		if (ImGui::IsItemClicked())
 		{
 			m_SelectionContext = entity;
+			
+			if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0))
+				g_DoubleClick = true;
 		}
 
 		bool entityDeleted = false;
@@ -208,7 +212,7 @@ namespace Hazel {
 			if (open)
 			{
 				uiFunction(component);
-				ImGui::TreePop();
+				ImGui::TreePop();s
 			}
 
 			if (removeComponent)
@@ -225,7 +229,15 @@ namespace Hazel {
 			char buffer[256];
 			memset(buffer, 0, sizeof(buffer));
 			std::strncpy(buffer, tag.c_str(), sizeof(buffer));
-			if (ImGui::InputText("##Tag", buffer, sizeof(buffer)))
+
+			// Entity has been double-clicked from the Scene Hierarchy Panel, so we interpret that as an attempt to rename it.
+			if(g_DoubleClick)
+			{
+				ImGui::SetKeyboardFocusHere(0);
+				g_DoubleClick = false;
+			}
+
+			if (ImGui::InputText("##Tag", buffer, sizeof(buffer), ImGuiInputTextFlags_AutoSelectAll))
 			{
 				tag = std::string(buffer);
 			}


### PR DESCRIPTION
…from Scene Hierarchy Panel

#### Describe the issue (if no issue has been made)
Not really much of an issue, just a convention that I believe most GUIs follow and that could be added to Hazelnut as well.

#### PR impact 
 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix 
Quality of life improvement feature to Hazelnut. After the user double-clicks on an entity's tag from the Scene Hierarchy Panel, its text input is automatically set on focus. Two details to give special attention: a global `bool g_DoubleClick` was created for this, which could easily be transformed into a member variable of `SceneHierarchyPanel`. I'm not sure which is preferable but I volunteer to make the adaptation if necessary; second detail is, I couldn't get it to only select the entire text if it was double-clicked from the scene hierarchy panel, my solution was quite buggy, so I just made it so interacting with the tag text input always selects everything, which may be undesirable as well. This behavior is also demonstrated in the capture below.

https://user-images.githubusercontent.com/51202489/188043421-707786b4-c0b6-443d-a453-491f3bcd0617.mp4