### PR TITLE
Add pre-build commands.

### DIFF
--- a/Hazel-ScriptCore/premake5.lua
+++ b/Hazel-ScriptCore/premake5.lua
@@ -2,6 +2,7 @@ project "Hazel-ScriptCore"
 	kind "SharedLib"
 	language "C#"
 	dotnetframework "4.7.2"
+	namespace "Hazel"
 
 	targetdir ("../Hazelnut/Resources/Scripts")
 	objdir ("../Hazelnut/Resources/Scripts/Intermediates")

--- a/Hazel/premake5.lua
+++ b/Hazel/premake5.lua
@@ -75,6 +75,13 @@ project "Hazel"
 			"%{Library.WinVersion}",
 			"%{Library.BCrypt}",
 		}
+		
+		prebuildcommands
+		{
+			'"$(DevEnvDir)devenv" "$(SolutionPath)" /Build $(configuration) /project "$(SolutionDir)Hazel-ScriptCore\\Hazel-ScriptCore.csproj"',
+			'IF EXIST "$(SolutionDir)Hazelnut\\SandboxProject\\Assets\\Scripts\\Sandbox.sln" ("$(DevEnvDir)devenv" "$(SolutionDir)Hazelnut\\SandboxProject\\Assets\\Scripts\\Sandbox.sln" /Build $(configuration) /project "$(SolutionDir)Hazelnut\\SandboxProject\\Assets\\Scripts\\Sandbox.csproj") ELSE (ECHO Sandbox Solution Not Found!)'
+		}
+		prebuildmessage "\nBuilding Hazel-ScriptCore.csproj ...\nBuilding Sandbox.csproj ..."
 
 	filter "configurations:Debug"
 		defines "HZ_DEBUG"

--- a/Hazelnut/SandboxProject/Assets/Scripts/premake5.lua
+++ b/Hazelnut/SandboxProject/Assets/Scripts/premake5.lua
@@ -23,6 +23,7 @@ project "Sandbox"
 	kind "SharedLib"
 	language "C#"
 	dotnetframework "4.7.2"
+	namespace "Sandbox"
 
 	targetdir ("Binaries")
 	objdir ("Intermediates")


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
1. Everytime after updating C# scripts, we need to build its solution manually, like Ctrl + B.
    Now just build Hazal.sln or **HIT F5** directly!
2. Also see #582 .

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | #582
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
1. Will build C# projects first when building Hazel C++ projects. Added the pre-build commands in the Hazel premake file.
    By the way, it checks whether the sandbox solution exists and notifies.
2. Only set C# project root namespace. <= Added ```namespace``` line in the C# premake files.
