### PR TITLE
Added transform copying

### DIFF
--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -166,12 +166,34 @@ namespace Hazel {
 
 		// Physics
 		{
+			// Copies transform from Hazel to Box2D
+			auto view = m_Registry.view<Rigidbody2DComponent>();
+			for (auto e : view)
+			{
+				Entity entity = { e, this };
+				auto& transform = entity.GetComponent<TransformComponent>();
+				auto& rb2d = entity.GetComponent<Rigidbody2DComponent>();
+
+				b2Body* body = (b2Body*)rb2d.RuntimeBody;
+				glm::vec3 translation = transform.Translation;
+				float angle = transform.Rotation.z;
+
+				const auto& bodyPosition = body->GetPosition();
+				const float bodyAngle = body->GetAngle();
+
+				bool awake = bodyPosition.x != transform.Translation.x || bodyPosition.y != transform.Translation.y || bodyAngle != angle;
+
+				body->SetTransform({ translation.x, translation.y }, angle);
+
+				if (awake)
+					body->SetAwake(true);
+			}
+
 			const int32_t velocityIterations = 6;
 			const int32_t positionIterations = 2;
 			m_PhysicsWorld->Step(ts, velocityIterations, positionIterations);
 
 			// Retrieve transform from Box2D
-			auto view = m_Registry.view<Rigidbody2DComponent>();
 			for (auto e : view)
 			{
 				Entity entity = { e, this };
@@ -239,12 +261,34 @@ namespace Hazel {
 	{
 		// Physics
 		{
+			// Copies transform from Hazel to Box2D
+			auto view = m_Registry.view<Rigidbody2DComponent>();
+			for (auto e : view)
+			{
+				Entity entity = { e, this };
+				auto& transform = entity.GetComponent<TransformComponent>();
+				auto& rb2d = entity.GetComponent<Rigidbody2DComponent>();
+
+				b2Body* body = (b2Body*)rb2d.RuntimeBody;
+				glm::vec3 translation = transform.Translation;
+				float angle = transform.Rotation.z;
+
+				const auto& bodyPosition = body->GetPosition();
+				const float bodyAngle = body->GetAngle();
+
+				bool awake = bodyPosition.x != transform.Translation.x || bodyPosition.y != transform.Translation.y || bodyAngle != angle;
+
+				body->SetTransform({ translation.x, translation.y }, angle);
+
+				if (awake)
+					body->SetAwake(true);
+			}
+
 			const int32_t velocityIterations = 6;
 			const int32_t positionIterations = 2;
 			m_PhysicsWorld->Step(ts, velocityIterations, positionIterations);
 
 			// Retrieve transform from Box2D
-			auto view = m_Registry.view<Rigidbody2DComponent>();
 			for (auto e : view)
 			{
 				Entity entity = { e, this };


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
During runtime or simulation, editing the `TransformComponent` of an entity with a `Rigidbody2DComponent` does not update neither the `TransformComponent` nor the `b2Body`. This means that the transform can not be updated during simulation to either test a physics object at a new location and can not be updated during runtime for gameplay reasons.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
Partially fixes the copying issue, as now translation and rotation are copied. Scale isn't copied yet, though that can be added at a later time.

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Before having Box2D step and update physics, copying the translation and z rotation from the `TransformComponent` into the `b2Body` and check if the `b2Body` should be awoken.

#### Additional context
As of right now, this only affects the position and the rotation of the `b2Body`, and does not change the attached collider's size. In the future, I may implement this.
- [ ] Add scaling for `BoxCollider2D`
- [ ] Add scaling for `CircleCollider2D`
