### PR TITLE
Fixed wrong matrix multiplication order in OrthographicCamera

### DIFF
--- a/Hazel/src/Hazel/Renderer/OrthographicCamera.cpp
+++ b/Hazel/src/Hazel/Renderer/OrthographicCamera.cpp
@@ -25,8 +25,8 @@ namespace Hazel {
 	{
 		HZ_PROFILE_FUNCTION();
 
-		glm::mat4 transform = glm::translate(glm::mat4(1.0f), m_Position) *
-			glm::rotate(glm::mat4(1.0f), glm::radians(m_Rotation), glm::vec3(0, 0, 1));
+		glm::mat4 transform = glm::rotate(glm::mat4(1.0f), glm::radians(m_Rotation), glm::vec3(0, 0, 1)) *
+            glm::translate(glm::mat4(1.0f), m_Position);
 
 		m_ViewMatrix = glm::inverse(transform);
 		m_ViewProjectionMatrix = m_ProjectionMatrix * m_ViewMatrix;


### PR DESCRIPTION
Currently, in the orthographic camera's view-projection matrix recalculation method, the rotation transformation is applied *before* the translation, which is the wrong order for a proper transform.

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

This PR addresses the issue by swapping the position of both operands.