### PR TITLE
Implemented Texture Icons/Thumbnails

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -40,6 +40,8 @@ namespace Hazel {
 		m_EditorScene = CreateRef<Scene>();
 		m_ActiveScene = m_EditorScene;
 
+		m_SceneHierarchyPanel.Init();
+
 		auto commandLineArgs = Application::Get().GetSpecification().CommandLineArgs;
 		if (commandLineArgs.Count > 1)
 		{

--- a/Hazelnut/src/Panels/ContentBrowserPanel.cpp
+++ b/Hazelnut/src/Panels/ContentBrowserPanel.cpp
@@ -5,6 +5,17 @@
 
 namespace Hazel {
 
+	namespace Utils {
+
+		bool IsImageFile(const std::filesystem::path& path)
+		{
+			if (path.extension() == ".png")
+				return true;
+
+			return false;
+		}
+
+	}
 	// Once we have projects, change this
 	extern const std::filesystem::path g_AssetPath = "assets";
 
@@ -13,6 +24,16 @@ namespace Hazel {
 	{
 		m_DirectoryIcon = Texture2D::Create("Resources/Icons/ContentBrowser/DirectoryIcon.png");
 		m_FileIcon = Texture2D::Create("Resources/Icons/ContentBrowser/FileIcon.png");
+
+		// Loading Textures
+		for (auto& directoryEntry : std::filesystem::recursive_directory_iterator(g_AssetPath))
+		{
+			const auto& path = directoryEntry.path();
+			const auto& filenameString = path.string();
+
+			if (Utils::IsImageFile(path))
+				m_TextureIcons[filenameString] = Texture2D::Create(filenameString);
+		}
 	}
 
 	void ContentBrowserPanel::OnImGuiRender()
@@ -21,7 +42,7 @@ namespace Hazel {
 
 		if (m_CurrentDirectory != std::filesystem::path(g_AssetPath))
 		{
-			if (ImGui::Button("<-"))
+			if (ImGui::Button("Back"))
 			{
 				m_CurrentDirectory = m_CurrentDirectory.parent_path();
 			}
@@ -44,7 +65,14 @@ namespace Hazel {
 			std::string filenameString = path.filename().string();
 			
 			ImGui::PushID(filenameString.c_str());
-			Ref<Texture2D> icon = directoryEntry.is_directory() ? m_DirectoryIcon : m_FileIcon;
+			Ref<Texture2D> icon = nullptr;
+
+			if (Utils::IsImageFile(path))
+				icon = m_TextureIcons[path.string()];
+
+			else
+				icon = directoryEntry.is_directory() ? m_DirectoryIcon : m_FileIcon;
+
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
 			ImGui::ImageButton((ImTextureID)icon->GetRendererID(), { thumbnailSize, thumbnailSize }, { 0, 1 }, { 1, 0 });
 

--- a/Hazelnut/src/Panels/ContentBrowserPanel.h
+++ b/Hazelnut/src/Panels/ContentBrowserPanel.h
@@ -17,6 +17,7 @@ namespace Hazel {
 		
 		Ref<Texture2D> m_DirectoryIcon;
 		Ref<Texture2D> m_FileIcon;
+		std::unordered_map<std::string, Ref<Texture2D>> m_TextureIcons;
 	};
 
 }

--- a/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.cpp
@@ -26,6 +26,11 @@ namespace Hazel {
 		SetContext(context);
 	}
 
+	void SceneHierarchyPanel::Init()
+	{
+		m_DefaultTexture = Texture2D::Create(1, 1);
+	}
+
 	void SceneHierarchyPanel::SetContext(const Ref<Scene>& context)
 	{
 		m_Context = context;
@@ -401,11 +406,15 @@ namespace Hazel {
 				ImGui::PopStyleColor();
 		});
 
-		DrawComponent<SpriteRendererComponent>("Sprite Renderer", entity, [](auto& component)
+		DrawComponent<SpriteRendererComponent>("Sprite Renderer", entity, [this](auto& component)
 		{
 			ImGui::ColorEdit4("Color", glm::value_ptr(component.Color));
 			
-			ImGui::Button("Texture", ImVec2(100.0f, 0.0f));
+			uint32_t buttonTex = component.Texture ? component.Texture->GetRendererID()
+				: m_DefaultTexture->GetRendererID();
+
+			ImGui::ImageButton((ImTextureID)buttonTex, ImVec2{ 100.0f, 100.0f });
+
 			if (ImGui::BeginDragDropTarget())
 			{
 				if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("CONTENT_BROWSER_ITEM"))

--- a/Hazelnut/src/Panels/SceneHierarchyPanel.h
+++ b/Hazelnut/src/Panels/SceneHierarchyPanel.h
@@ -12,6 +12,7 @@ namespace Hazel {
 		SceneHierarchyPanel() = default;
 		SceneHierarchyPanel(const Ref<Scene>& scene);
 
+		void Init();
 		void SetContext(const Ref<Scene>& scene);
 
 		void OnImGuiRender();
@@ -27,6 +28,7 @@ namespace Hazel {
 	private:
 		Ref<Scene> m_Context;
 		Entity m_SelectionContext;
+		Ref<Texture2D> m_DefaultTexture;
 	};
 
 }


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
- Currently Hazel has no Image Icons/Thumbnails in `ContentBrowserPanel`, it is represented by Standard File Icon
- Same with `SpriteRendererComponent` in Properties Panel, there is only `Texture` drag/drop button and not an Image Button Icon

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:
- Adds Textures as Image Icons in `ContentBrowserPanel`
- Adds `ImGui.ImageButton` instead of `ImGui.Button` for Texture in `SpriteRendererComponent` in Properties Panel

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
A short description of what this fix is and how it fixed the issue you described.

#### Additional context
Currently if Texture file was deleted or modified, we won't be able to erase it from `std.unordered_map` cache. Possible solution is to use filewatcher
