### PR TITLE
Changed std::string to std::filesystem::path in the Filewatcher

### DIFF
--- a/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
+++ b/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
@@ -130,7 +130,7 @@ namespace Hazel {
 		std::unordered_map<UUID, Ref<ScriptInstance>> EntityInstances;
 		std::unordered_map<UUID, ScriptFieldMap> EntityScriptFields;
 
-		Scope<filewatch::FileWatch<std::string>> AppAssemblyFileWatcher;
+		Scope<filewatch::FileWatch<std::filesystem::path>> AppAssemblyFileWatcher;
 		bool AssemblyReloadPending = false;
 
 		bool EnableDebugging = true;
@@ -142,7 +142,7 @@ namespace Hazel {
 
 	static ScriptEngineData* s_Data = nullptr;
 
-	static void OnAppAssemblyFileSystemEvent(const std::string& path, const filewatch::Event change_type)
+	static void OnAppAssemblyFileSystemEvent(const std::filesystem::path& path, const filewatch::Event change_type)
 	{
 		if (!s_Data->AssemblyReloadPending && change_type == filewatch::Event::modified)
 		{
@@ -252,7 +252,7 @@ namespace Hazel {
 
 		s_Data->AppAssemblyImage = mono_assembly_get_image(s_Data->AppAssembly);
 
-		s_Data->AppAssemblyFileWatcher = CreateScope<filewatch::FileWatch<std::string>>(filepath.string(), OnAppAssemblyFileSystemEvent);
+		s_Data->AppAssemblyFileWatcher = CreateScope<filewatch::FileWatch<std::filesystem::path>>(filepath, OnAppAssemblyFileSystemEvent);
 		s_Data->AssemblyReloadPending = false;
 		return true;
 	}


### PR DESCRIPTION


#### Describe the issue (if no issue has been made)
std::filesystem::path is used when loading assemblies, so it makes more sense to use this for the filewatcher too, instead of converting a std::filesystem::path to std::string. This is natively supported by the library.

```
static bool LoadAssembly(const std::filesystem::path& filepath);
static bool LoadAppAssembly(const std::filesystem::path& filepath);
```

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
A short description of what this fix is and how it fixed the issue you described.

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.

Tested if it still works, which it should since this is not really a breaking change and is supported by the library.
Worked fine when changing a file in the sandbox project and recompiling while running.
