### PR TITLE
OnCreate invkoe after all instances created

### DIFF
--- a/Hazel/src/Hazel/Scene/Scene.cpp
+++ b/Hazel/src/Hazel/Scene/Scene.cpp
@@ -146,8 +146,9 @@ namespace Hazel {
 			for (auto e : view)
 			{
 				Entity entity = { e, this };
-				ScriptEngine::OnCreateEntity(entity);
+				ScriptEngine::CreateEntity(entity);
 			}
+			ScriptEngine::OnCreateEntities();
 		}
 	}
 

--- a/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
+++ b/Hazel/src/Hazel/Scripting/ScriptEngine.cpp
@@ -283,10 +283,10 @@ namespace Hazel {
 		return s_Data->EntityClasses.find(fullClassName) != s_Data->EntityClasses.end();
 	}
 
-	void ScriptEngine::OnCreateEntity(Entity entity)
+	void ScriptEngine::CreateEntity(Entity entity)
 	{
 		const auto& sc = entity.GetComponent<ScriptComponent>();
-		if (ScriptEngine::EntityClassExists(sc.ClassName))
+		if (EntityClassExists(sc.ClassName))
 		{
 			UUID entityID = entity.GetUUID();
 
@@ -300,7 +300,13 @@ namespace Hazel {
 				for (const auto& [name, fieldInstance] : fieldMap)
 					instance->SetFieldValueInternal(name, fieldInstance.m_Buffer);
 			}
+		}
+	}
 
+	void ScriptEngine::OnCreateEntities()
+	{
+		for (auto& [entity, instance] : s_Data->EntityInstances)
+		{
 			instance->InvokeOnCreate();
 		}
 	}

--- a/Hazel/src/Hazel/Scripting/ScriptEngine.h
+++ b/Hazel/src/Hazel/Scripting/ScriptEngine.h
@@ -153,7 +153,8 @@ namespace Hazel {
 		static void OnRuntimeStop();
 
 		static bool EntityClassExists(const std::string& fullClassName);
-		static void OnCreateEntity(Entity entity);
+		static void CreateEntity(Entity entity);
+		static void OnCreateEntities();
 		static void OnUpdateEntity(Entity entity, Timestep ts);
 
 		static Scene* GetSceneContext();


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
Here is my modification plan after I pushed this issuse -#606 .


#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | 1 
Other PRs this solves    | None 

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
I splited the method "OnCreateEntity(Entity entity)" into "CreateEntity(Entity entity)" and "OnCreateEntities()".
One is to register all instances in the instances map, another one is to invoke their OnCreate() function.

#### Additional context
Add any other context about the solution here. Did you test the solution on all (relevant) platforms?
If not, create a [task list](https://help.github.com/en/articles/about-task-lists) here.
