### PR TITLE
FontAtlas Image Format changed From RGB to RGBA

### DIFF
--- a/Hazel/src/Hazel/Renderer/Font.cpp
+++ b/Hazel/src/Hazel/Renderer/Font.cpp
@@ -33,7 +33,7 @@ namespace Hazel {
 		TextureSpecification spec;
 		spec.Width = bitmap.width;
 		spec.Height = bitmap.height;
-		spec.Format = ImageFormat::RGB8;
+		spec.Format = ImageFormat::RGBA8;
 		spec.GenerateMips = false;
 
 		Ref<Texture2D> texture = Texture2D::Create(spec);
@@ -96,7 +96,7 @@ namespace Hazel {
 		atlasPacker.getDimensions(width, height);
 		emSize = atlasPacker.getScale();
 
-		m_AtlasTexture = CreateAndCacheAtlas<uint8_t, float, 3, msdf_atlas::msdfGenerator>("Test", (float)emSize, m_Data->Glyphs, m_Data->FontGeometry, width, height);
+		m_AtlasTexture = CreateAndCacheAtlas<uint8_t, float, 4, msdf_atlas::mtsdfGenerator>("Test", (float)emSize, m_Data->Glyphs, m_Data->FontGeometry, width, height);
 
 
 #if 0


### PR DESCRIPTION
msdf Atlas is using only 3 channels which might not be Ideal in long term, but mtsdf is using 4 of them , so I've changed function which generates Atlas from msdf to mtsdf.

I just had to change 3 characters.