### PR TITLE
fix: fixed the screen flickering issue when resizing the window from …

### DIFF
--- a/Hazel/src/Hazel/Core/Application.cpp
+++ b/Hazel/src/Hazel/Core/Application.cpp
@@ -100,6 +100,8 @@ namespace Hazel {
 
 			ExecuteMainThreadQueue();
 
+			m_Window->OnUpdate();
+
 			if (!m_Minimized)
 			{
 				{
@@ -119,7 +121,7 @@ namespace Hazel {
 				m_ImGuiLayer->End();
 			}
 
-			m_Window->OnUpdate();
+			m_Window->OnRender();
 		}
 	}
 

--- a/Hazel/src/Hazel/Core/Window.h
+++ b/Hazel/src/Hazel/Core/Window.h
@@ -30,6 +30,7 @@ namespace Hazel {
 		virtual ~Window() = default;
 
 		virtual void OnUpdate() = 0;
+		virtual void OnRender() = 0;
 
 		virtual uint32_t GetWidth() const = 0;
 		virtual uint32_t GetHeight() const = 0;

--- a/Hazel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hazel/src/Platform/Windows/WindowsWindow.cpp
@@ -177,6 +177,12 @@ namespace Hazel {
 		HZ_PROFILE_FUNCTION();
 
 		glfwPollEvents();
+	}
+
+	void WindowsWindow::OnRender()
+	{
+		HZ_PROFILE_FUNCTION();
+
 		m_Context->SwapBuffers();
 	}
 

--- a/Hazel/src/Platform/Windows/WindowsWindow.h
+++ b/Hazel/src/Platform/Windows/WindowsWindow.h
@@ -14,6 +14,7 @@ namespace Hazel {
 		virtual ~WindowsWindow();
 
 		void OnUpdate() override;
+		void OnRender() override;
 
 		unsigned int GetWidth() const override { return m_Data.Width; }
 		unsigned int GetHeight() const override { return m_Data.Height; }


### PR DESCRIPTION
…the bottom.

#### Describe the issue (if no issue has been made)
A lot of people may have overlooked an issue where there is a flicker or delay in the screen when adjusting the window size from below the window. This is due to the improper handling of GLFW input events timing. We should handle input events at the beginning of the main loop, instead of handling events and swapping buffers at the end of rendering.

#### PR impact _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None or #number(s)
Other PRs this solves    | None or #number(s)

#### Proposed fix _(Make sure you've read [on how to contribute](https://github.com/TheCherno/Hazel/blob/master/.github/CONTRIBUTING.md) to Hazel)_
Add a new interface method OnRender in Window.h, move the SwapBuffer operation to OnRender, and move the glfwPollEvents operation to OnUpdate. Call the window's OnUpdate at the beginning of the main loop in Application and call OnRender at the end of the render pipeline. Further discussion may be needed for naming, it could also be OnPreUpdate and OnLateUpdate, but for now, OnUpdate and OnRender should be more appropriate according to the current logic.

#### Additional context
Tested on Windows 10, 19041.264
