### PR TITLE
Update .gitmodules to replace backslashes with forward slashes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,6 +23,6 @@
 [submodule "Hazel/vendor/Box2D"]
 	path = Hazel/vendor/Box2D
 	url = https://github.com/thecherno/box2d
-[submodule "Hazel\\vendor\\msdf-atlas-gen"]
-	path = Hazel\\vendor\\msdf-atlas-gen
+[submodule "Hazel/vendor/msdf-atlas-gen"]
+	path = Hazel/vendor/msdf-atlas-gen
 	url = https://github.com/TheCherno/msdf-atlas-gen


### PR DESCRIPTION
When executing scripts/setup.bat, the msdf-atlas-gen submodule cannot be initialised because the .gitmodules entry contains backslashes instead of forward slashes.

Replacing the backslashes with forward slashes fixes the problem.