### PR TITLE
Allow drag/drop textures in editor (Untested)

### DIFF
--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -290,11 +290,17 @@ namespace Hazel {
 				{
 					// Drag & Drop Textures
 					bool valid = true;
-					if(int(m_HoveredEntity <=0 || !m_HoveredEntity.HasComponent<TagComponent>())
+					if((int)m_HoveredEntity <=0 || !m_HoveredEntity.HasComponent<TagComponent>())
 						valid = false;
 					if(valid && m_HoveredEntity.HasComponent<SpriteRendererComponent>())
 					{
 						*m_SelectedEntity = m_HoveredEntity;
+						m_SelectedEntity->GetComponent<SpriteRendererComponent>().Texture = Texture2D::Create(path.string());
+					} else {
+						// Create a new entity
+						Entity e = m_ActiveScene->CreateEntity("New Sprite");
+						e.AddComponent<SpriteRendererComponent>();
+						*m_SelectedEntity = e;
 						m_SelectedEntity->GetComponent<SpriteRendererComponent>().Texture = Texture2D::Create(path.string());
 					}
 				}

--- a/Hazelnut/src/EditorLayer.cpp
+++ b/Hazelnut/src/EditorLayer.cpp
@@ -282,8 +282,22 @@ namespace Hazel {
 		{
 			if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("CONTENT_BROWSER_ITEM"))
 			{
-				const wchar_t* path = (const wchar_t*)payload->Data;
-				OpenScene(path);
+				std::filesystem::path = (const wchar_t*)payload->Data;
+				auto ext = path.extension();
+				if(ext == ".yaml" || ext == ".hazel")
+					OpenScene(path);
+				else if(ext == ".png")
+				{
+					// Drag & Drop Textures
+					bool valid = true;
+					if(int(m_HoveredEntity <=0 || !m_HoveredEntity.HasComponent<TagComponent>())
+						valid = false;
+					if(valid && m_HoveredEntity.HasComponent<SpriteRendererComponent>())
+					{
+						*m_SelectedEntity = m_HoveredEntity;
+						m_SelectedEntity->GetComponent<SpriteRendererComponent>().Texture = Texture2D::Create(path.string());
+					}
+				}
 			}
 			ImGui::EndDragDropTarget();
 		}


### PR DESCRIPTION
May need to rework the ImGuiPayload creation, adapted from: https://github.com/NoahGWood/VersaMachina/blob/main/VersaEditor/src/EditorLayer.cpp

#### Describe the issue (if no issue has been made)
People generally expect to be able to drag/drop items from the content pane into the viewport and onto game objects.

#### PR impact 
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None 
Other PRs this solves    |  https://github.com/TheCherno/Hazel/pull/487

#### Proposed fix
Check if texture file has been dropped on sprite component in the editor & set the texture

#### Additional context
Tasks to validate:
- [ ] Build Hazelnut
- [ ] Start Hazelnut
- [ ] Add entity to scene
- [ ] Add SpriteRendererComponent to entity
- [ ] Drag & drop a texture (.png file) from the content browser panel into an empty space on viewport
- [ ] Drag & drop a texture (.png file) from the content browser panel onto the quad in the viewport