### PR TITLE
Update Premake and Vulkan versions

### DIFF
--- a/scripts/SetupPremake.py
+++ b/scripts/SetupPremake.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import Utils
 
 class PremakeConfiguration:
-    premakeVersion = "5.0.0-beta1"
+    premakeVersion = "5.0.0-beta2"
     premakeZipUrls = f"https://github.com/premake/premake-core/releases/download/v{premakeVersion}/premake-{premakeVersion}-windows.zip"
     premakeLicenseUrl = "https://raw.githubusercontent.com/premake/premake-core/master/LICENSE.txt"
     premakeDirectory = "./vendor/premake/bin"

--- a/scripts/SetupVulkan.py
+++ b/scripts/SetupVulkan.py
@@ -10,7 +10,7 @@ from urllib.request import urlopen
 
 class VulkanConfiguration:
     requiredVulkanVersion = "1.3."
-    installVulkanVersion = "1.3.216.0"
+    installVulkanVersion = "1.3.268.0"
     vulkanDirectory = "./Hazel/vendor/VulkanSDK"
 
     @classmethod


### PR DESCRIPTION
Bumped up the Premake version to "5.0.0-beta2" and the Vulkan version to "1.3.268.0" for integration with the latest features and improvements.

Confirmed its working state.
