### PR TITLE
Remove two redundant lines of code setting io.DisplaySize in ImGuiLayer.cpp

### DIFF
--- a/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
+++ b/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp
@@ -97,8 +97,6 @@ namespace Hazel {
 		HZ_PROFILE_FUNCTION();
 
 		ImGuiIO& io = ImGui::GetIO();
-		Application& app = Application::Get();
-		io.DisplaySize = ImVec2((float)app.GetWindow().GetWidth(), (float)app.GetWindow().GetHeight());
 
 		// Rendering
 		ImGui::Render();


### PR DESCRIPTION
https://github.com/TheCherno/Hazel/blob/1feb70572fa87fa1c4ba784a2cfeada5b4a500db/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp#L100-L101
This is redundant because the "ImGui_ImplGlfw_NewFrame();" has done this work. That is in 
https://github.com/TheCherno/Hazel/blob/1feb70572fa87fa1c4ba784a2cfeada5b4a500db/Hazel/src/Hazel/ImGui/ImGuiLayer.cpp#L89-L91 
And the definition of ImGui_ImplGlfw_NewFrame() is in:https://github.com/TheCherno/imgui/blob/3cf61f67de73153e29e0c26f23d80edbaf120a3d/examples/imgui_impl_glfw.cpp#L473-L477

So, I removed them. Not confirmed its working state.