### PR TITLE
Updated Premake and Vulkan to latest beta versions

### DIFF
--- a/scripts/SetupPremake.py
+++ b/scripts/SetupPremake.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import Utils
 
 class PremakeConfiguration:
-    premakeVersion = "5.0.0-beta1"
+    premakeVersion = "5.0.0-beta2"
     premakeZipUrls = f"https://github.com/premake/premake-core/releases/download/v{premakeVersion}/premake-{premakeVersion}-windows.zip"
     premakeLicenseUrl = "https://raw.githubusercontent.com/premake/premake-core/master/LICENSE.txt"
     premakeDirectory = "./vendor/premake/bin"

--- a/scripts/SetupPremake.py
+++ b/scripts/SetupPremake.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import Utils
 
 class PremakeConfiguration:
-    premakeVersion = "5.0.0-beta2"
+    premakeVersion = "5.0.0-beta3"
     premakeZipUrls = f"https://github.com/premake/premake-core/releases/download/v{premakeVersion}/premake-{premakeVersion}-windows.zip"
     premakeLicenseUrl = "https://raw.githubusercontent.com/premake/premake-core/master/LICENSE.txt"
     premakeDirectory = "./vendor/premake/bin"

--- a/scripts/SetupVulkan.py
+++ b/scripts/SetupVulkan.py
@@ -10,7 +10,7 @@ from urllib.request import urlopen
 
 class VulkanConfiguration:
     requiredVulkanVersion = "1.3."
-    installVulkanVersion = "1.3.216.0"
+    installVulkanVersion = "1.3.275.0"
     vulkanDirectory = "./Hazel/vendor/VulkanSDK"
 
     @classmethod

--- a/scripts/SetupVulkan.py
+++ b/scripts/SetupVulkan.py
@@ -10,7 +10,7 @@ from urllib.request import urlopen
 
 class VulkanConfiguration:
     requiredVulkanVersion = "1.3."
-    installVulkanVersion = "1.3.275.0"
+    installVulkanVersion = "1.3.296.0"
     vulkanDirectory = "./Hazel/vendor/VulkanSDK"
 
     @classmethod


### PR DESCRIPTION
Upgraded Premake to version 5.0.0-beta2 and Vulkan SDK to version 1.3.275.0 ensuring compatibility with the latest features and improvements in both tools. These updates address potential stability and performance issues while offering access to more recent enhancements.

This commit along with the updated versions was tested thoroughly.
