### PR TITLE
Fixed OpenGL Texture glad inclusion

### DIFF
--- a/Hazel/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/Hazel/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -2,6 +2,7 @@
 #include "Platform/OpenGL/OpenGLTexture.h"
 
 #include <stb_image.h>
+#include <glad/glad.h>
 
 namespace Hazel {
 

--- a/Hazel/src/Platform/OpenGL/OpenGLTexture.h
+++ b/Hazel/src/Platform/OpenGL/OpenGLTexture.h
@@ -2,7 +2,7 @@
 
 #include "Hazel/Renderer/Texture.h"
 
-#include <glad/glad.h>
+typedef unsigned int GLenum;
 
 namespace Hazel {
 


### PR DESCRIPTION
- Moved inclusion of glad from header to implementation file

#### Describe the issue (if no issue has been made)
glad.h was included in the header file for OpenGLTexture, while all other OpenGL related classes included glad in their implementation files

#### Proposed fix
This moves the inclusion of glad to the implementation file of OpenGLTexture, to fit the same structure as the other GL related classes, as well as avoiding potential issues if/when implementing other APIs - as well as it keeps glad outside of the engine core

#### Additional context
The solution was tested on Windows 11 with Visual Studio 2022 on the latest version of the VC++ compiler
